### PR TITLE
feat(assembly): add dynamic bridging for low-confidence transitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,6 +378,8 @@ Each issue should be completable in 1-3 coding sessions. If an issue takes more 
 | `feature/api-stations` | merged | Station CRUD + track management + segment library endpoints. 68 integration tests |
 | `feature/api-timelines` | merged | Timeline manifest endpoints: create, get active, history, get by ID. 27 integration tests |
 | `feature/tts-quality` | PR #30 | Audio quality scoring: `scoreSegment()` + `batchScore()` in `packages/tts/src/quality.ts`. WAV integrity checks (RIFF/WAVE header, 16-bit PCM, sample rate ≥ 24000), duration validation per segment type, silence detection (leading/trailing/internal gaps). Returns `QualityResult` with `quality_score` (0-1) and `quality_flags`. 17 tests |
+| `feature/assembly-manifest` | PR #33 (merged) | Timeline manifest builder (`buildManifest`, `validateManifest`, `getManifestStats`) + segment selector (`selectSegments`) with all assembly rules + CLI. 46 tests |
+| `feature/assembly-bridging` | PR #34 | Dynamic bridging fallback: `BridgingContext`, `LLMProvider`/`TTSProvider` interfaces, `StubLLMProvider` (6 deterministic templates), `StubTTSProvider` (silent WAV), `detectLowConfidence()`, `generateBridge()`, `synthesizeBoundary()`. Selector generates bridge segments on-the-fly when library candidates are empty/overused/energy-mismatched. Stubs gated behind `allowStubs` flag. Error-resilient (try/catch fallback). 72 tests |
 
 ### API Endpoints (from `feature/api-stations`)
 
@@ -419,9 +421,29 @@ Each issue should be completable in 1-3 coding sessions. If an issue takes more 
 
 **Test setup:** `src/test-setup.ts` provides `createTestDb()` — creates an in-memory SQLite database with all migrations applied. Test files mock `db.js` via `vi.mock` and clean tables in `beforeEach`.
 
+### Assembly Pipeline (`packages/assembly/`)
+
+The assembly package is now functional with segment selection, manifest building, and dynamic bridging.
+
+**Selector** (`src/selector.ts`): `selectSegments(station, library, config)` → `Promise<TimelineEntry[]>`. Async. Enforces all assembly rules (intro/outro, 60-70% coverage, no-repeat-within-5, energy ±1/±2 widening, ad-lib limits, artist shoutout adjacency, time-of-day). Uses seeded PRNG (mulberry32) for deterministic output.
+
+**Bridging** (`src/bridging.ts`): When library candidates are low-confidence (empty pool, energy mismatch at ±1, all overused >10), generates transition segments dynamically via pluggable `LLMProvider` + `TTSProvider`. Also synthesizes `show_intro`/`show_outro` boundary segments when library has none. Stubs gated behind `config.allowStubs` — production requires real providers.
+
+**Manifest** (`src/manifest.ts`): `buildManifest()`, `validateManifest()`, `getManifestStats()`. Validation: entries non-empty, first/last must be segment, no consecutive segments in middle, all fields present.
+
+**Config** (`AssemblyConfig`):
+```typescript
+{
+  timeOfDay: string;
+  variationSeed: number;
+  llmProvider?: LLMProvider;
+  ttsProvider?: TTSProvider;
+  allowStubs?: boolean;  // must be true for stub providers in test/dev
+}
+```
+
 ### Not yet started
 
-- Assembly pipeline (`packages/assembly/` — empty)
 - Tools web app (`apps/tools/` — empty)
 - Mobile app stub implementations (interfaces in place, bodies unimplemented)
 
@@ -439,6 +461,6 @@ Each issue should be completable in 1-3 coding sessions. If an issue takes more 
 
 **Phase 1: Foundation** — Set up Chatterbox, define schemas, build Segment Studio MVP, produce initial segment library (300-500 segments for hip-hop/R&B), build Station Manager MVP, build assembly pipeline MVP, deploy first test station.
 
-**Next up:** Merge pending feature branches → run seed script → build assembly pipeline.
+**Next up:** Merge pending feature branches → run seed script → build tools web app (Station Manager, Segment Studio, Assembly Dashboard).
 
 **Phase 2: Mobile App** — Run v1 → v2 UI migration (`v2-migration/migrate-ui.sh`). Implement stubs against v2 backend. Priority order: Storage → AuthService → api → MusicProvider → SessionEngine/QueueManager (consume timeline manifests) → AudioCoordinator/SegmentController (segment playback). Do NOT rebuild or significantly modify the UI — implement the stub interfaces so existing screens work with the new backend.

--- a/packages/assembly/src/bridging.test.ts
+++ b/packages/assembly/src/bridging.test.ts
@@ -5,6 +5,7 @@ import {
   StubTTSProvider,
   detectLowConfidence,
   generateBridge,
+  synthesizeBoundary,
   type BridgingContext,
   type LLMProvider,
   type TTSProvider,
@@ -98,11 +99,14 @@ describe('StubLLMProvider', () => {
 describe('StubTTSProvider', () => {
   const tts = new StubTTSProvider();
 
-  it('returns an audioPath and duration_ms', async () => {
+  it('returns a deterministic audioPath and duration_ms', async () => {
     const result = await tts.generateSegment('Test script for bridging', 'transition');
-    expect(result.audioPath).toMatch(/^stub:\/\/bridging\//);
+    expect(result.audioPath).toMatch(/^stub:\/\/bridging\/\d+\.wav$/);
     expect(result.duration_ms).toBeGreaterThanOrEqual(4000);
     expect(result.duration_ms).toBeLessThanOrEqual(8000);
+    // Same input produces same path
+    const result2 = await tts.generateSegment('Test script for bridging', 'transition');
+    expect(result.audioPath).toBe(result2.audioPath);
   });
 
   it('clamps short scripts to minimum 4000ms', async () => {
@@ -204,6 +208,136 @@ describe('generateBridge', () => {
 });
 
 // ---------------------------------------------------------------------------
+// synthesizeBoundary
+// ---------------------------------------------------------------------------
+
+describe('synthesizeBoundary', () => {
+  it('generates a show_intro segment', async () => {
+    const seg = await synthesizeBoundary(
+      'show_intro', 'Late Night R&B', ['hip-hop'], ['chill'], new StubTTSProvider(),
+    );
+    expect(seg.type).toBe('show_intro');
+    expect(seg.segment_id).toMatch(/^SEG-SI-\d{5}$/);
+    expect(seg.genre_tags).toEqual(['hip-hop']);
+    expect(seg.script_text.length).toBeGreaterThan(0);
+  });
+
+  it('generates a show_outro segment', async () => {
+    const seg = await synthesizeBoundary(
+      'show_outro', 'Late Night R&B', ['hip-hop'], ['chill'], new StubTTSProvider(),
+    );
+    expect(seg.type).toBe('show_outro');
+    expect(seg.segment_id).toMatch(/^SEG-SO-\d{5}$/);
+  });
+
+  it('is deterministic for the same station name', async () => {
+    const a = await synthesizeBoundary(
+      'show_intro', 'Late Night R&B', ['hip-hop'], ['chill'], new StubTTSProvider(),
+    );
+    const b = await synthesizeBoundary(
+      'show_intro', 'Late Night R&B', ['hip-hop'], ['chill'], new StubTTSProvider(),
+    );
+    expect(a.script_text).toBe(b.script_text);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider validation
+// ---------------------------------------------------------------------------
+
+describe('selectSegments provider validation', () => {
+  const TRACKS: TracklistEntry[] = [
+    makeTrack({ artist: 'SZA', title: 'Kill Bill' }),
+  ];
+
+  function makeStation() {
+    return {
+      station_id: 'station-001',
+      name: 'Test',
+      description: 'Test',
+      genre_tags: ['hip-hop'],
+      mood_tags: ['chill'],
+      cover_art_url: '',
+      rotation_schedule: { frequency: 'daily', time_of_day_target: 'evening', days: ['mon'] },
+      tracklist: TRACKS,
+      provider_availability: { apple_music: {}, spotify: {} },
+    };
+  }
+
+  it('throws when providers are missing and allowStubs is not set', async () => {
+    await expect(
+      selectSegments(makeStation(), [], { timeOfDay: 'evening', variationSeed: 42 }),
+    ).rejects.toThrow('selectSegments requires llmProvider and ttsProvider');
+  });
+
+  it('allows stubs when allowStubs is true', async () => {
+    const entries = await selectSegments(makeStation(), [], {
+      timeOfDay: 'evening',
+      variationSeed: 42,
+      allowStubs: true,
+    });
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it('works when both providers are explicitly supplied', async () => {
+    const entries = await selectSegments(makeStation(), [], {
+      timeOfDay: 'evening',
+      variationSeed: 42,
+      llmProvider: new StubLLMProvider(),
+      ttsProvider: new StubTTSProvider(),
+    });
+    expect(entries.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateBridge error handling
+// ---------------------------------------------------------------------------
+
+describe('generateBridge error resilience in selector', () => {
+  it('falls back to library candidate when bridge generation fails', async () => {
+    const lib = [
+      makeSegment({ segment_id: 'SEG-SI-00001', type: 'show_intro', energy_level: 3 }),
+      makeSegment({ segment_id: 'SEG-SO-00001', type: 'show_outro', energy_level: 3 }),
+      // All overused — triggers bridging, but bridge will fail
+      makeSegment({ segment_id: 'SEG-TR-00001', type: 'transition', energy_level: 3, usage_count: 20 }),
+    ];
+
+    const failingLLM: LLMProvider = {
+      generateBridgingScript: () => Promise.reject(new Error('LLM down')),
+    };
+
+    const entries = await selectSegments(
+      {
+        station_id: 'station-001',
+        name: 'Test',
+        description: 'Test',
+        genre_tags: ['hip-hop'],
+        mood_tags: ['chill'],
+        cover_art_url: '',
+        rotation_schedule: { frequency: 'daily', time_of_day_target: 'evening', days: ['mon'] },
+        tracklist: [
+          makeTrack({ artist: 'SZA', title: 'Kill Bill' }),
+          makeTrack({ artist: 'Frank Ocean', title: 'Nights' }),
+        ],
+        provider_availability: { apple_music: {}, spotify: {} },
+      },
+      lib,
+      {
+        timeOfDay: 'evening',
+        variationSeed: 42,
+        llmProvider: failingLLM,
+        ttsProvider: new StubTTSProvider(),
+      },
+    );
+
+    // Should not throw — songs are still present
+    const songs = entries.filter((e) => e.type === 'song');
+    expect(songs).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Selector integration with bridging
 // ---------------------------------------------------------------------------
 
@@ -211,6 +345,7 @@ describe('selectSegments with bridging', () => {
   const DEFAULT_CONFIG: AssemblyConfig = {
     timeOfDay: 'evening',
     variationSeed: 42,
+    allowStubs: true,
   };
 
   const TRACKS: TracklistEntry[] = [

--- a/packages/assembly/src/bridging.test.ts
+++ b/packages/assembly/src/bridging.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Segment, SegmentType, TracklistEntry } from '@onay/core';
+import {
+  StubLLMProvider,
+  StubTTSProvider,
+  detectLowConfidence,
+  generateBridge,
+  type BridgingContext,
+  type LLMProvider,
+  type TTSProvider,
+} from './bridging';
+import { selectSegments, type AssemblyConfig } from './selector';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeTrack(overrides: Partial<TracklistEntry> & { artist: string; title: string }): TracklistEntry {
+  return {
+    canonical_id: `${overrides.artist}-${overrides.title}`.toLowerCase().replace(/\s+/g, '-'),
+    duration_ms: 210000,
+    ...overrides,
+  };
+}
+
+function makeSegment(overrides: Partial<Segment> & { segment_id: string; type: SegmentType }): Segment {
+  return {
+    genre_tags: ['hip-hop'],
+    mood_tags: ['chill'],
+    artist_refs: [],
+    energy_level: 3,
+    duration_ms: 6000,
+    quality_score: 0.8,
+    exaggeration_level: 0.5,
+    created_at: '2026-01-01T00:00:00Z',
+    usage_count: 0,
+    audio_url: `https://cdn.onay.fm/segments/${overrides.segment_id}.wav`,
+    script_text: 'Test script',
+    ...overrides,
+  };
+}
+
+const TRACK_A = makeTrack({ artist: 'SZA', title: 'Kill Bill' });
+const TRACK_B = makeTrack({ artist: 'Frank Ocean', title: 'Nights' });
+
+function makeBridgingContext(overrides?: Partial<BridgingContext>): BridgingContext {
+  return {
+    previousSong: TRACK_A,
+    nextSong: TRACK_B,
+    stationMood: ['chill', 'late-night'],
+    stationGenre: ['hip-hop', 'r&b'],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// StubLLMProvider
+// ---------------------------------------------------------------------------
+
+describe('StubLLMProvider', () => {
+  const llm = new StubLLMProvider();
+
+  it('generates a script containing both artist names', async () => {
+    const script = await llm.generateBridgingScript(makeBridgingContext());
+    expect(script).toContain('SZA');
+    expect(script).toContain('Frank Ocean');
+  });
+
+  it('is deterministic — same songs produce same script', async () => {
+    const ctx = makeBridgingContext();
+    const a = await llm.generateBridgingScript(ctx);
+    const b = await llm.generateBridgingScript(ctx);
+    expect(a).toBe(b);
+  });
+
+  it('produces different scripts for different song pairs', async () => {
+    const ctx1 = makeBridgingContext();
+    const ctx2 = makeBridgingContext({
+      previousSong: makeTrack({ artist: 'Drake', title: 'Passionfruit' }),
+      nextSong: makeTrack({ artist: 'The Weeknd', title: 'Blinding Lights' }),
+    });
+    const a = await llm.generateBridgingScript(ctx1);
+    const b = await llm.generateBridgingScript(ctx2);
+    // Different song pairs should hash to different templates (or at least different fills)
+    expect(a).not.toBe(b);
+  });
+
+  it('returns a non-empty string', async () => {
+    const script = await llm.generateBridgingScript(makeBridgingContext());
+    expect(script.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StubTTSProvider
+// ---------------------------------------------------------------------------
+
+describe('StubTTSProvider', () => {
+  const tts = new StubTTSProvider();
+
+  it('returns an audioPath and duration_ms', async () => {
+    const result = await tts.generateSegment('Test script for bridging', 'transition');
+    expect(result.audioPath).toMatch(/^stub:\/\/bridging\//);
+    expect(result.duration_ms).toBeGreaterThanOrEqual(4000);
+    expect(result.duration_ms).toBeLessThanOrEqual(8000);
+  });
+
+  it('clamps short scripts to minimum 4000ms', async () => {
+    const result = await tts.generateSegment('Hi', 'transition');
+    expect(result.duration_ms).toBe(4000);
+  });
+
+  it('clamps long scripts to maximum 8000ms', async () => {
+    const result = await tts.generateSegment('x'.repeat(200), 'transition');
+    expect(result.duration_ms).toBe(8000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectLowConfidence
+// ---------------------------------------------------------------------------
+
+describe('detectLowConfidence', () => {
+  it('returns true when candidate pool is empty', () => {
+    expect(detectLowConfidence([], 3, 2)).toBe(true);
+  });
+
+  it('returns true when no candidates match energy tolerance', () => {
+    const candidates = [
+      makeSegment({ segment_id: 'SEG-TR-00001', type: 'transition', energy_level: 1 }),
+    ];
+    // target 5, tolerance 1 → need 4-5, candidate is 1
+    expect(detectLowConfidence(candidates, 5, 1)).toBe(true);
+  });
+
+  it('returns true when all candidates are overused (usage_count > 10)', () => {
+    const candidates = [
+      makeSegment({ segment_id: 'SEG-TR-00001', type: 'transition', usage_count: 11 }),
+      makeSegment({ segment_id: 'SEG-TR-00002', type: 'transition', usage_count: 15 }),
+    ];
+    expect(detectLowConfidence(candidates, 3, 2)).toBe(true);
+  });
+
+  it('returns false when good candidates exist', () => {
+    const candidates = [
+      makeSegment({ segment_id: 'SEG-TR-00001', type: 'transition', energy_level: 3, usage_count: 2 }),
+    ];
+    expect(detectLowConfidence(candidates, 3, 1)).toBe(false);
+  });
+
+  it('returns false when at least one candidate has low usage', () => {
+    const candidates = [
+      makeSegment({ segment_id: 'SEG-TR-00001', type: 'transition', usage_count: 15 }),
+      makeSegment({ segment_id: 'SEG-TR-00002', type: 'transition', usage_count: 5 }),
+    ];
+    expect(detectLowConfidence(candidates, 3, 2)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateBridge
+// ---------------------------------------------------------------------------
+
+describe('generateBridge', () => {
+  it('returns a complete Segment object', async () => {
+    const ctx = makeBridgingContext();
+    const seg = await generateBridge(ctx, new StubLLMProvider(), new StubTTSProvider());
+
+    expect(seg.segment_id).toMatch(/^SEG-TR-\d{5}$/);
+    expect(seg.type).toBe('transition');
+    expect(seg.genre_tags).toEqual(['hip-hop', 'r&b']);
+    expect(seg.mood_tags).toEqual(['chill', 'late-night']);
+    expect(seg.artist_refs).toContain('SZA');
+    expect(seg.artist_refs).toContain('Frank Ocean');
+    expect(seg.energy_level).toBe(3);
+    expect(seg.quality_score).toBe(0.7);
+    expect(seg.usage_count).toBe(0);
+    expect(seg.script_text).toContain('SZA');
+    expect(seg.audio_url).toMatch(/^stub:\/\//);
+    expect(seg.duration_ms).toBeGreaterThanOrEqual(4000);
+  });
+
+  it('calls the LLM provider with correct context', async () => {
+    const ctx = makeBridgingContext();
+    const mockLLM: LLMProvider = {
+      generateBridgingScript: vi.fn().mockResolvedValue('Custom bridge script'),
+    };
+    const seg = await generateBridge(ctx, mockLLM, new StubTTSProvider());
+
+    expect(mockLLM.generateBridgingScript).toHaveBeenCalledWith(ctx);
+    expect(seg.script_text).toBe('Custom bridge script');
+  });
+
+  it('calls the TTS provider with the generated script', async () => {
+    const mockTTS: TTSProvider = {
+      generateSegment: vi.fn().mockResolvedValue({ audioPath: '/test/audio.wav', duration_ms: 5000 }),
+    };
+    const seg = await generateBridge(makeBridgingContext(), new StubLLMProvider(), mockTTS);
+
+    expect(mockTTS.generateSegment).toHaveBeenCalledWith(expect.any(String), 'transition');
+    expect(seg.audio_url).toBe('/test/audio.wav');
+    expect(seg.duration_ms).toBe(5000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Selector integration with bridging
+// ---------------------------------------------------------------------------
+
+describe('selectSegments with bridging', () => {
+  const DEFAULT_CONFIG: AssemblyConfig = {
+    timeOfDay: 'evening',
+    variationSeed: 42,
+  };
+
+  const TRACKS: TracklistEntry[] = [
+    makeTrack({ artist: 'SZA', title: 'Kill Bill' }),
+    makeTrack({ artist: 'Frank Ocean', title: 'Nights' }),
+    makeTrack({ artist: 'Tyler, the Creator', title: 'EARFQUAKE' }),
+    makeTrack({ artist: 'Kendrick Lamar', title: 'HUMBLE.' }),
+    makeTrack({ artist: 'Drake', title: 'Passionfruit' }),
+  ];
+
+  function makeStation(overrides?: Partial<Parameters<typeof makeTrack>[0]> & Record<string, unknown>) {
+    return {
+      station_id: 'station-001',
+      name: 'Late Night R&B',
+      description: 'Smooth vibes',
+      genre_tags: ['hip-hop', 'r&b'],
+      mood_tags: ['chill', 'late-night'],
+      cover_art_url: 'https://cdn.onay.fm/covers/station-001.jpg',
+      rotation_schedule: { frequency: 'daily', time_of_day_target: 'evening', days: ['mon'] },
+      tracklist: TRACKS,
+      provider_availability: { apple_music: {}, spotify: {} },
+      ...overrides,
+    };
+  }
+
+  it('falls back to bridging when library is empty (no intro/outro available)', async () => {
+    const station = makeStation();
+    const entries = await selectSegments(station, [], DEFAULT_CONFIG);
+
+    // With an empty library: no intro/outro from library, but bridging may produce transitions
+    // All songs should still be present
+    const songs = entries.filter((e) => e.type === 'song');
+    expect(songs).toHaveLength(5);
+  });
+
+  it('generates bridged segments when all candidates are overused', async () => {
+    const overusedLib = [
+      makeSegment({ segment_id: 'SEG-SI-00001', type: 'show_intro', energy_level: 3 }),
+      makeSegment({ segment_id: 'SEG-SO-00001', type: 'show_outro', energy_level: 3 }),
+      // Only transitions, all overused
+      makeSegment({ segment_id: 'SEG-TR-00001', type: 'transition', energy_level: 3, usage_count: 20 }),
+      makeSegment({ segment_id: 'SEG-TR-00002', type: 'transition', energy_level: 3, usage_count: 15 }),
+    ];
+
+    const trackingLLM: LLMProvider & { calls: BridgingContext[] } = {
+      calls: [],
+      async generateBridgingScript(ctx: BridgingContext) {
+        this.calls.push(ctx);
+        return `Bridge from ${ctx.previousSong.artist} to ${ctx.nextSong.artist}`;
+      },
+    };
+
+    const entries = await selectSegments(makeStation(), overusedLib, {
+      ...DEFAULT_CONFIG,
+      llmProvider: trackingLLM,
+      ttsProvider: new StubTTSProvider(),
+    });
+
+    // Bridged segments should have been generated
+    expect(trackingLLM.calls.length).toBeGreaterThan(0);
+
+    // All songs still present
+    const songs = entries.filter((e) => e.type === 'song');
+    expect(songs).toHaveLength(5);
+
+    // Some segments should be bridged (auto-generated IDs)
+    const segments = entries.filter((e) => e.type === 'segment');
+    expect(segments.length).toBeGreaterThan(2); // at least intro + outro + some bridges
+  });
+
+  it('uses library segments when confidence is high (no bridging needed)', async () => {
+    const goodLib = [
+      makeSegment({ segment_id: 'SEG-SI-00001', type: 'show_intro', energy_level: 3 }),
+      makeSegment({ segment_id: 'SEG-SO-00001', type: 'show_outro', energy_level: 3 }),
+      ...Array.from({ length: 10 }, (_, i) =>
+        makeSegment({
+          segment_id: `SEG-TR-${String(i).padStart(5, '0')}`,
+          type: 'transition',
+          energy_level: 3,
+          usage_count: 0,
+        }),
+      ),
+    ];
+
+    const trackingLLM: LLMProvider & { callCount: number } = {
+      callCount: 0,
+      async generateBridgingScript(ctx: BridgingContext) {
+        this.callCount++;
+        return 'Should not be called';
+      },
+    };
+
+    await selectSegments(makeStation(), goodLib, {
+      ...DEFAULT_CONFIG,
+      llmProvider: trackingLLM,
+      ttsProvider: new StubTTSProvider(),
+    });
+
+    // LLM should not have been called since library has good candidates
+    expect(trackingLLM.callCount).toBe(0);
+  });
+
+  it('still produces deterministic output with bridging stubs', async () => {
+    const station = makeStation();
+    const minLib = [
+      makeSegment({ segment_id: 'SEG-SI-00001', type: 'show_intro', energy_level: 3 }),
+      makeSegment({ segment_id: 'SEG-SO-00001', type: 'show_outro', energy_level: 3 }),
+    ];
+
+    // With stubs, the song order and structure should be consistent
+    const a = await selectSegments(station, minLib, { ...DEFAULT_CONFIG, variationSeed: 99 });
+    const b = await selectSegments(station, minLib, { ...DEFAULT_CONFIG, variationSeed: 99 });
+
+    const aSongs = a.filter((e) => e.type === 'song');
+    const bSongs = b.filter((e) => e.type === 'song');
+    expect(aSongs).toEqual(bSongs);
+  });
+});

--- a/packages/assembly/src/bridging.ts
+++ b/packages/assembly/src/bridging.ts
@@ -1,0 +1,179 @@
+import type { Segment, SegmentType, TracklistEntry } from '@onay/core';
+import { generateSegmentId } from '@onay/core';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BridgingContext {
+  previousSong: TracklistEntry;
+  nextSong: TracklistEntry;
+  stationMood: string[];
+  stationGenre: string[];
+}
+
+export interface LLMProvider {
+  generateBridgingScript(context: BridgingContext): Promise<string>;
+}
+
+export interface TTSProvider {
+  generateSegment(
+    script: string,
+    type: SegmentType,
+  ): Promise<{ audioPath: string; duration_ms: number }>;
+}
+
+// ---------------------------------------------------------------------------
+// Stub LLM Provider
+// ---------------------------------------------------------------------------
+
+const BRIDGING_TEMPLATES = [
+  'Alright, switching it up from {prev} to {next}...',
+  "That was {prev} setting the mood, now let's bring in {next}...",
+  "We're moving from {prev} into {next} — stay with me...",
+  '{prev} just blessed your ears, and {next} is about to do the same...',
+  "From {prev} to {next}, we're keeping the energy right...",
+  "Can't get enough of {prev}, but wait till you hear {next}...",
+];
+
+/** Simple deterministic hash of a string to a number. */
+function hashString(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+export class StubLLMProvider implements LLMProvider {
+  async generateBridgingScript(context: BridgingContext): Promise<string> {
+    const key = `${context.previousSong.title}:${context.nextSong.title}`;
+    const idx = hashString(key) % BRIDGING_TEMPLATES.length;
+    const template = BRIDGING_TEMPLATES[idx];
+    return template
+      .replace('{prev}', context.previousSong.artist)
+      .replace('{next}', context.nextSong.artist);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stub TTS Provider — generates a silent WAV (same pattern as packages/tts)
+// ---------------------------------------------------------------------------
+
+function buildSilentWav(durationMs: number): Buffer {
+  const sampleRate = 22050;
+  const numChannels = 1;
+  const bytesPerSample = 2; // 16-bit
+  const numSamples = Math.floor((sampleRate * durationMs) / 1000);
+  const dataSize = numSamples * numChannels * bytesPerSample;
+  const headerSize = 44;
+  const fileSize = headerSize + dataSize;
+
+  const buf = Buffer.alloc(fileSize);
+  let offset = 0;
+
+  // RIFF header
+  buf.write('RIFF', offset);
+  offset += 4;
+  buf.writeUInt32LE(fileSize - 8, offset);
+  offset += 4;
+  buf.write('WAVE', offset);
+  offset += 4;
+
+  // fmt sub-chunk
+  buf.write('fmt ', offset);
+  offset += 4;
+  buf.writeUInt32LE(16, offset);
+  offset += 4; // sub-chunk size
+  buf.writeUInt16LE(1, offset);
+  offset += 2; // PCM
+  buf.writeUInt16LE(numChannels, offset);
+  offset += 2;
+  buf.writeUInt32LE(sampleRate, offset);
+  offset += 4;
+  buf.writeUInt32LE(sampleRate * numChannels * bytesPerSample, offset);
+  offset += 4; // byte rate
+  buf.writeUInt16LE(numChannels * bytesPerSample, offset);
+  offset += 2; // block align
+  buf.writeUInt16LE(bytesPerSample * 8, offset);
+  offset += 2; // bits per sample
+
+  // data sub-chunk (all zeros = silence)
+  buf.write('data', offset);
+  offset += 4;
+  buf.writeUInt32LE(dataSize, offset);
+  // remaining bytes are already 0
+
+  return buf;
+}
+
+export class StubTTSProvider implements TTSProvider {
+  async generateSegment(
+    script: string,
+    _type: SegmentType,
+  ): Promise<{ audioPath: string; duration_ms: number }> {
+    // Estimate duration at ~80ms per character, clamped to 4-8s for transitions
+    const estimated = Math.min(8000, Math.max(4000, script.length * 80));
+    // Build the WAV but don't write to disk — in tests the audioPath is a placeholder
+    buildSilentWav(estimated);
+    return {
+      audioPath: `stub://bridging/${Date.now()}.wav`,
+      duration_ms: estimated,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Low-confidence detection
+// ---------------------------------------------------------------------------
+
+const HIGH_USAGE_THRESHOLD = 10;
+
+export function detectLowConfidence(
+  candidates: Segment[],
+  energyTarget: number,
+  energyTolerance: number,
+): boolean {
+  // Empty pool
+  if (candidates.length === 0) return true;
+
+  // No candidates within energy tolerance
+  const withinEnergy = candidates.filter(
+    (s) => Math.abs(s.energy_level - energyTarget) <= energyTolerance,
+  );
+  if (withinEnergy.length === 0) return true;
+
+  // All candidates are overused
+  if (candidates.every((s) => s.usage_count > HIGH_USAGE_THRESHOLD)) return true;
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Bridge generation
+// ---------------------------------------------------------------------------
+
+export async function generateBridge(
+  context: BridgingContext,
+  llm: LLMProvider,
+  tts: TTSProvider,
+): Promise<Segment> {
+  const script = await llm.generateBridgingScript(context);
+  const { audioPath, duration_ms } = await tts.generateSegment(script, 'transition');
+
+  return {
+    segment_id: generateSegmentId('transition'),
+    type: 'transition',
+    genre_tags: [...context.stationGenre],
+    mood_tags: [...context.stationMood],
+    artist_refs: [context.previousSong.artist, context.nextSong.artist],
+    energy_level: 3,
+    duration_ms,
+    quality_score: 0.7, // generated segments get a baseline score
+    exaggeration_level: 0.5,
+    created_at: new Date().toISOString(),
+    usage_count: 0,
+    audio_url: audioPath,
+    script_text: script,
+  };
+}

--- a/packages/assembly/src/bridging.ts
+++ b/packages/assembly/src/bridging.ts
@@ -117,10 +117,56 @@ export class StubTTSProvider implements TTSProvider {
     // Build the WAV but don't write to disk — in tests the audioPath is a placeholder
     buildSilentWav(estimated);
     return {
-      audioPath: `stub://bridging/${Date.now()}.wav`,
+      audioPath: `stub://bridging/${hashString(script)}.wav`,
       duration_ms: estimated,
     };
   }
+}
+
+// ---------------------------------------------------------------------------
+// Boundary segment synthesis (show_intro / show_outro)
+// ---------------------------------------------------------------------------
+
+const INTRO_TEMPLATES = [
+  "What's good, you're locked in with Onay — let's get this started.",
+  "Welcome back, it's Onay on the ones and twos — we got a vibe tonight.",
+  "You already know what it is — Onay here, and we're about to set it off.",
+];
+
+const OUTRO_TEMPLATES = [
+  "That's a wrap for now — Onay signing off. Stay smooth out there.",
+  "We out. Onay loves you. Catch you on the next one.",
+  "And that's the show — Onay saying peace. Keep the vibe going.",
+];
+
+export async function synthesizeBoundary(
+  type: 'show_intro' | 'show_outro',
+  stationName: string,
+  stationGenre: string[],
+  stationMood: string[],
+  tts: TTSProvider,
+): Promise<Segment> {
+  const templates = type === 'show_intro' ? INTRO_TEMPLATES : OUTRO_TEMPLATES;
+  const idx = hashString(stationName) % templates.length;
+  const script = templates[idx];
+
+  const { audioPath, duration_ms } = await tts.generateSegment(script, type);
+
+  return {
+    segment_id: generateSegmentId(type),
+    type,
+    genre_tags: [...stationGenre],
+    mood_tags: [...stationMood],
+    artist_refs: [],
+    energy_level: 3,
+    duration_ms,
+    quality_score: 0.7,
+    exaggeration_level: 0.5,
+    created_at: new Date().toISOString(),
+    usage_count: 0,
+    audio_url: audioPath,
+    script_text: script,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/assembly/src/cli.ts
+++ b/packages/assembly/src/cli.ts
@@ -89,6 +89,8 @@ async function main() {
   const config: AssemblyConfig = {
     timeOfDay: station.rotation_schedule?.time_of_day_target ?? 'evening',
     variationSeed: Date.now(),
+    // TODO: Replace with real LLM/TTS providers once Ollama/Chatterbox are integrated
+    allowStubs: true,
   };
   const entries = await selectSegments(station, segments, config);
 

--- a/packages/assembly/src/cli.ts
+++ b/packages/assembly/src/cli.ts
@@ -90,7 +90,7 @@ async function main() {
     timeOfDay: station.rotation_schedule?.time_of_day_target ?? 'evening',
     variationSeed: Date.now(),
   };
-  const entries = selectSegments(station, segments, config);
+  const entries = await selectSegments(station, segments, config);
 
   console.log('Building manifest...');
   const manifest = buildManifest(stationId, entries);

--- a/packages/assembly/src/index.ts
+++ b/packages/assembly/src/index.ts
@@ -2,3 +2,10 @@ export type { AssemblyConfig } from './selector';
 export { selectSegments } from './selector';
 export type { ValidationResult, ManifestStats } from './manifest';
 export { buildManifest, validateManifest, getManifestStats } from './manifest';
+export type { BridgingContext, LLMProvider, TTSProvider } from './bridging';
+export {
+  StubLLMProvider,
+  StubTTSProvider,
+  detectLowConfidence,
+  generateBridge,
+} from './bridging';

--- a/packages/assembly/src/index.ts
+++ b/packages/assembly/src/index.ts
@@ -8,4 +8,5 @@ export {
   StubTTSProvider,
   detectLowConfidence,
   generateBridge,
+  synthesizeBoundary,
 } from './bridging';

--- a/packages/assembly/src/selector.test.ts
+++ b/packages/assembly/src/selector.test.ts
@@ -158,8 +158,8 @@ describe('selectSegments', () => {
   const library = buildLibrary();
 
   describe('show intro and outro', () => {
-    it('starts with a show_intro segment', () => {
-      const entries = selectSegments(station, library, DEFAULT_CONFIG);
+    it('starts with a show_intro segment', async () => {
+      const entries = await selectSegments(station, library, DEFAULT_CONFIG);
       expect(entries.length).toBeGreaterThan(0);
       expect(entries[0].type).toBe('segment');
       const firstSeg = entries[0] as Extract<TimelineEntry, { type: 'segment' }>;
@@ -167,8 +167,8 @@ describe('selectSegments', () => {
       expect(introIds).toContain(firstSeg.segment_id);
     });
 
-    it('ends with a show_outro segment', () => {
-      const entries = selectSegments(station, library, DEFAULT_CONFIG);
+    it('ends with a show_outro segment', async () => {
+      const entries = await selectSegments(station, library, DEFAULT_CONFIG);
       const last = entries[entries.length - 1];
       expect(last.type).toBe('segment');
       const lastSeg = last as Extract<TimelineEntry, { type: 'segment' }>;
@@ -176,20 +176,20 @@ describe('selectSegments', () => {
       expect(outroIds).toContain(lastSeg.segment_id);
     });
 
-    it('picks best available intro when no genre match exists', () => {
+    it('picks best available intro when no genre match exists', async () => {
       const jazzStation = makeStation({ genre_tags: ['jazz'] });
       // Library has only hip-hop tagged intros, but should still pick one
-      const entries = selectSegments(jazzStation, library, DEFAULT_CONFIG);
+      const entries = await selectSegments(jazzStation, library, DEFAULT_CONFIG);
       expect(entries[0].type).toBe('segment');
     });
   });
 
   describe('60-70% transition coverage', () => {
-    it('places segments at roughly 60-70% of transitions', () => {
+    it('places segments at roughly 60-70% of transitions', async () => {
       // Run with multiple seeds to average out
       const coverages: number[] = [];
       for (let seed = 1; seed <= 20; seed++) {
-        const entries = selectSegments(station, library, { ...DEFAULT_CONFIG, variationSeed: seed });
+        const entries = await selectSegments(station, library, { ...DEFAULT_CONFIG, variationSeed: seed });
         const songs = songEntries(entries);
         const transitionCount = songs.length - 1; // gaps between songs
         if (transitionCount === 0) continue;
@@ -218,10 +218,10 @@ describe('selectSegments', () => {
   });
 
   describe('no-repeat-within-5 rule', () => {
-    it('never uses the same segment_id within 5 slots of itself', () => {
+    it('never uses the same segment_id within 5 slots of itself', async () => {
       // Use a small library to force potential repeats
       const smallLib = library.slice(0, 15);
-      const entries = selectSegments(station, smallLib, DEFAULT_CONFIG);
+      const entries = await selectSegments(station, smallLib, DEFAULT_CONFIG);
       const segIds = getSegmentIds(entries);
 
       for (let i = 0; i < segIds.length; i++) {
@@ -230,8 +230,8 @@ describe('selectSegments', () => {
       }
     });
 
-    it('enforces no-repeat with full library', () => {
-      const entries = selectSegments(station, library, DEFAULT_CONFIG);
+    it('enforces no-repeat with full library', async () => {
+      const entries = await selectSegments(station, library, DEFAULT_CONFIG);
       const segIds = getSegmentIds(entries);
 
       for (let i = 0; i < segIds.length; i++) {
@@ -242,7 +242,7 @@ describe('selectSegments', () => {
   });
 
   describe('energy matching', () => {
-    it('selects segments within energy tolerance of target', () => {
+    it('selects segments within energy tolerance of target', async () => {
       // Create a library with extreme energy levels only
       const extremeLib = [
         makeSegment({ segment_id: 'SEG-SI-99901', type: 'show_intro', energy_level: 1 }),
@@ -254,7 +254,7 @@ describe('selectSegments', () => {
         makeSegment({ segment_id: 'SEG-TR-99905', type: 'transition', energy_level: 4 }),
       ];
 
-      const entries = selectSegments(station, extremeLib, DEFAULT_CONFIG);
+      const entries = await selectSegments(station, extremeLib, DEFAULT_CONFIG);
       // All transition segments should exist in our library
       const segIds = getSegmentIds(entries);
       const allLibIds = extremeLib.map((s) => s.segment_id);
@@ -263,7 +263,7 @@ describe('selectSegments', () => {
       }
     });
 
-    it('widens tolerance to ±2 when no ±1 match exists', () => {
+    it('widens tolerance to ±2 when no ±1 match exists', async () => {
       // Library with only energy 1 transitions, target will be 3
       const narrowLib = [
         makeSegment({ segment_id: 'SEG-SI-88801', type: 'show_intro', energy_level: 3 }),
@@ -275,7 +275,7 @@ describe('selectSegments', () => {
         makeSegment({ segment_id: 'SEG-TR-88805', type: 'transition', energy_level: 5 }),
       ];
 
-      const entries = selectSegments(station, narrowLib, DEFAULT_CONFIG);
+      const entries = await selectSegments(station, narrowLib, DEFAULT_CONFIG);
       // Should still place some segments despite energy mismatch (±2 tolerance)
       const segs = segmentEntries(entries);
       expect(segs.length).toBeGreaterThan(2); // at least intro + outro + some transitions
@@ -283,7 +283,7 @@ describe('selectSegments', () => {
   });
 
   describe('ad-lib limits', () => {
-    it('places at most 2 ad-libs per show', () => {
+    it('places at most 2 ad-libs per show', async () => {
       // Library with many ad-libs to tempt overuse
       const adLibHeavy = [
         makeSegment({ segment_id: 'SEG-SI-77701', type: 'show_intro', energy_level: 3 }),
@@ -293,13 +293,13 @@ describe('selectSegments', () => {
         ),
       ];
 
-      const entries = selectSegments(station, adLibHeavy, DEFAULT_CONFIG);
+      const entries = await selectSegments(station, adLibHeavy, DEFAULT_CONFIG);
       const adLibIds = getSegmentIds(entries).filter((id) => id.startsWith('SEG-AL'));
       expect(adLibIds.length).toBeLessThanOrEqual(2);
     });
 
-    it('never places an ad-lib adjacent to another segment', () => {
-      const entries = selectSegments(station, library, DEFAULT_CONFIG);
+    it('never places an ad-lib adjacent to another segment', async () => {
+      const entries = await selectSegments(station, library, DEFAULT_CONFIG);
 
       for (let i = 0; i < entries.length; i++) {
         if (entries[i].type === 'segment') {
@@ -317,8 +317,8 @@ describe('selectSegments', () => {
   });
 
   describe('artist shoutout adjacency', () => {
-    it('only places artist shoutouts next to songs by that artist', () => {
-      const entries = selectSegments(station, library, DEFAULT_CONFIG);
+    it('only places artist shoutouts next to songs by that artist', async () => {
+      const entries = await selectSegments(station, library, DEFAULT_CONFIG);
 
       for (let i = 0; i < entries.length; i++) {
         if (entries[i].type !== 'segment') continue;
@@ -345,8 +345,8 @@ describe('selectSegments', () => {
       }
     });
 
-    it('does not place Beyonce shoutout when she is not in tracklist', () => {
-      const entries = selectSegments(station, library, DEFAULT_CONFIG);
+    it('does not place Beyonce shoutout when she is not in tracklist', async () => {
+      const entries = await selectSegments(station, library, DEFAULT_CONFIG);
       const beyonceSeg = library.find((s) => s.artist_refs.includes('Beyonce'));
       const segIds = getSegmentIds(entries);
       expect(segIds).not.toContain(beyonceSeg!.segment_id);
@@ -354,8 +354,8 @@ describe('selectSegments', () => {
   });
 
   describe('time-of-day filtering', () => {
-    it('only includes time-of-day segments matching config.timeOfDay', () => {
-      const entries = selectSegments(station, library, DEFAULT_CONFIG); // timeOfDay: 'evening'
+    it('only includes time-of-day segments matching config.timeOfDay', async () => {
+      const entries = await selectSegments(station, library, DEFAULT_CONFIG); // timeOfDay: 'evening'
 
       for (const entry of entries) {
         if (entry.type !== 'segment') continue;
@@ -368,26 +368,26 @@ describe('selectSegments', () => {
       }
     });
 
-    it('excludes morning time-of-day segments when timeOfDay is evening', () => {
+    it('excludes morning time-of-day segments when timeOfDay is evening', async () => {
       const morningSeg = library.find(
         (s) => s.type === 'time_of_day' && s.mood_tags.includes('morning'),
       )!;
-      const entries = selectSegments(station, library, DEFAULT_CONFIG);
+      const entries = await selectSegments(station, library, DEFAULT_CONFIG);
       const segIds = getSegmentIds(entries);
       expect(segIds).not.toContain(morningSeg.segment_id);
     });
   });
 
   describe('deterministic output', () => {
-    it('produces identical output for the same seed', () => {
-      const a = selectSegments(station, library, { ...DEFAULT_CONFIG, variationSeed: 123 });
-      const b = selectSegments(station, library, { ...DEFAULT_CONFIG, variationSeed: 123 });
+    it('produces identical output for the same seed', async () => {
+      const a = await selectSegments(station, library, { ...DEFAULT_CONFIG, variationSeed: 123 });
+      const b = await selectSegments(station, library, { ...DEFAULT_CONFIG, variationSeed: 123 });
       expect(a).toEqual(b);
     });
 
-    it('produces different output for different seeds', () => {
-      const a = selectSegments(station, library, { ...DEFAULT_CONFIG, variationSeed: 1 });
-      const b = selectSegments(station, library, { ...DEFAULT_CONFIG, variationSeed: 2 });
+    it('produces different output for different seeds', async () => {
+      const a = await selectSegments(station, library, { ...DEFAULT_CONFIG, variationSeed: 1 });
+      const b = await selectSegments(station, library, { ...DEFAULT_CONFIG, variationSeed: 2 });
       // They may occasionally match on small libraries, but with 50+ segments this is extremely unlikely
       const aIds = getSegmentIds(a);
       const bIds = getSegmentIds(b);
@@ -396,36 +396,34 @@ describe('selectSegments', () => {
   });
 
   describe('sparse library', () => {
-    it('handles a library with only intro and outro', () => {
+    it('handles a library with only intro and outro', async () => {
       const minLib = [
         makeSegment({ segment_id: 'SEG-SI-00001', type: 'show_intro', energy_level: 3 }),
         makeSegment({ segment_id: 'SEG-SO-00001', type: 'show_outro', energy_level: 3 }),
       ];
 
-      const entries = selectSegments(station, minLib, DEFAULT_CONFIG);
-      // Should have intro + 15 songs + outro = 17
+      const entries = await selectSegments(station, minLib, DEFAULT_CONFIG);
+      // Should have intro + 15 songs + outro + bridged transitions
       expect(entries[0].type).toBe('segment');
       expect(entries[entries.length - 1].type).toBe('segment');
       expect(songEntries(entries)).toHaveLength(15);
     });
 
-    it('handles an empty library gracefully', () => {
-      const entries = selectSegments(station, [], DEFAULT_CONFIG);
-      // All songs, no segments
-      expect(entries).toHaveLength(15);
+    it('handles an empty library gracefully', async () => {
+      const entries = await selectSegments(station, [], DEFAULT_CONFIG);
+      // All songs present, bridged segments may be generated for transitions
       expect(songEntries(entries)).toHaveLength(15);
-      expect(segmentEntries(entries)).toHaveLength(0);
     });
 
-    it('handles an empty tracklist', () => {
+    it('handles an empty tracklist', async () => {
       const emptyStation = makeStation({ tracklist: [] });
-      const entries = selectSegments(emptyStation, library, DEFAULT_CONFIG);
+      const entries = await selectSegments(emptyStation, library, DEFAULT_CONFIG);
       expect(entries).toHaveLength(0);
     });
 
-    it('handles a single-track station', () => {
+    it('handles a single-track station', async () => {
       const singleStation = makeStation({ tracklist: [TRACKS[0]] });
-      const entries = selectSegments(singleStation, library, DEFAULT_CONFIG);
+      const entries = await selectSegments(singleStation, library, DEFAULT_CONFIG);
       // Intro + song + outro
       const songs = songEntries(entries);
       expect(songs).toHaveLength(1);
@@ -435,7 +433,7 @@ describe('selectSegments', () => {
   });
 
   describe('usage_count and quality_score preference', () => {
-    it('prefers segments with lower usage_count', () => {
+    it('prefers segments with lower usage_count', async () => {
       const lowUsage = makeSegment({
         segment_id: 'SEG-TR-LOW01',
         type: 'transition',
@@ -460,7 +458,7 @@ describe('selectSegments', () => {
 
       // Run multiple seeds — the low-usage one should be picked every time
       for (let seed = 1; seed <= 10; seed++) {
-        const entries = selectSegments(station, testLib, { ...DEFAULT_CONFIG, variationSeed: seed });
+        const entries = await selectSegments(station, testLib, { ...DEFAULT_CONFIG, variationSeed: seed });
         const transitionIds = getSegmentIds(entries).filter(
           (id) => id === lowUsage.segment_id || id === highUsage.segment_id,
         );
@@ -470,7 +468,7 @@ describe('selectSegments', () => {
       }
     });
 
-    it('prefers higher quality_score when usage_count is equal', () => {
+    it('prefers higher quality_score when usage_count is equal', async () => {
       const highQ = makeSegment({
         segment_id: 'SEG-TR-HIQ01',
         type: 'transition',
@@ -494,7 +492,7 @@ describe('selectSegments', () => {
       ];
 
       for (let seed = 1; seed <= 10; seed++) {
-        const entries = selectSegments(station, testLib, { ...DEFAULT_CONFIG, variationSeed: seed });
+        const entries = await selectSegments(station, testLib, { ...DEFAULT_CONFIG, variationSeed: seed });
         const transitionIds = getSegmentIds(entries).filter(
           (id) => id === highQ.segment_id || id === lowQ.segment_id,
         );
@@ -506,8 +504,8 @@ describe('selectSegments', () => {
   });
 
   describe('all songs are included', () => {
-    it('includes every track from the station tracklist in order', () => {
-      const entries = selectSegments(station, library, DEFAULT_CONFIG);
+    it('includes every track from the station tracklist in order', async () => {
+      const entries = await selectSegments(station, library, DEFAULT_CONFIG);
       const songs = songEntries(entries) as Extract<TimelineEntry, { type: 'song' }>[];
       expect(songs).toHaveLength(TRACKS.length);
       for (let i = 0; i < TRACKS.length; i++) {
@@ -519,8 +517,8 @@ describe('selectSegments', () => {
   });
 
   describe('timeline structure', () => {
-    it('never has two consecutive segments (except intro before first song)', () => {
-      const entries = selectSegments(station, library, DEFAULT_CONFIG);
+    it('never has two consecutive segments (except intro before first song)', async () => {
+      const entries = await selectSegments(station, library, DEFAULT_CONFIG);
 
       // After the intro, we should not see two segments in a row
       // (the intro is allowed to be followed by a song)

--- a/packages/assembly/src/selector.test.ts
+++ b/packages/assembly/src/selector.test.ts
@@ -131,6 +131,7 @@ function buildLibrary(): Segment[] {
 const DEFAULT_CONFIG: AssemblyConfig = {
   timeOfDay: 'evening',
   variationSeed: 42,
+  allowStubs: true,
 };
 
 // ---------------------------------------------------------------------------
@@ -255,11 +256,13 @@ describe('selectSegments', () => {
       ];
 
       const entries = await selectSegments(station, extremeLib, DEFAULT_CONFIG);
-      // All transition segments should exist in our library
+      // All segments should either come from our library or be bridged (auto-generated)
       const segIds = getSegmentIds(entries);
       const allLibIds = extremeLib.map((s) => s.segment_id);
       for (const id of segIds) {
-        expect(allLibIds).toContain(id);
+        const fromLibrary = allLibIds.includes(id);
+        const bridged = /^SEG-TR-\d{5}$/.test(id) && !allLibIds.includes(id);
+        expect(fromLibrary || bridged).toBe(true);
       }
     });
 
@@ -411,8 +414,19 @@ describe('selectSegments', () => {
 
     it('handles an empty library gracefully', async () => {
       const entries = await selectSegments(station, [], DEFAULT_CONFIG);
-      // All songs present, bridged segments may be generated for transitions
+      // All songs present
       expect(songEntries(entries)).toHaveLength(15);
+      // Synthesized boundaries: first entry is show_intro, last is show_outro
+      const segs = segmentEntries(entries) as Extract<TimelineEntry, { type: 'segment' }>[];
+      expect(segs.length).toBeGreaterThanOrEqual(2);
+      const firstSeg = segs[0];
+      const lastSeg = segs[segs.length - 1];
+      // Verify boundary segment IDs match show_intro / show_outro patterns
+      expect(firstSeg.segment_id).toMatch(/^SEG-SI-/);
+      expect(lastSeg.segment_id).toMatch(/^SEG-SO-/);
+      // First entry overall is the intro segment, last entry overall is the outro
+      expect(entries[0]).toBe(firstSeg);
+      expect(entries[entries.length - 1]).toBe(lastSeg);
     });
 
     it('handles an empty tracklist', async () => {

--- a/packages/assembly/src/selector.ts
+++ b/packages/assembly/src/selector.ts
@@ -1,4 +1,13 @@
 import type { Station, Segment, SegmentType, TimelineEntry, TracklistEntry } from '@onay/core';
+import {
+  detectLowConfidence,
+  generateBridge,
+  StubLLMProvider,
+  StubTTSProvider,
+  type BridgingContext,
+  type LLMProvider,
+  type TTSProvider,
+} from './bridging';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -7,6 +16,8 @@ import type { Station, Segment, SegmentType, TimelineEntry, TracklistEntry } fro
 export interface AssemblyConfig {
   timeOfDay: string;
   variationSeed: number;
+  llmProvider?: LLMProvider;
+  ttsProvider?: TTSProvider;
 }
 
 // ---------------------------------------------------------------------------
@@ -137,13 +148,15 @@ function getCandidates(
 // Main selector
 // ---------------------------------------------------------------------------
 
-export function selectSegments(
+export async function selectSegments(
   station: Station,
   library: Segment[],
   config: AssemblyConfig,
-): TimelineEntry[] {
+): Promise<TimelineEntry[]> {
   const rng = createRng(config.variationSeed);
   const tracklist = station.tracklist;
+  const llm = config.llmProvider ?? new StubLLMProvider();
+  const tts = config.ttsProvider ?? new StubTTSProvider();
 
   if (tracklist.length === 0) return [];
 
@@ -237,7 +250,17 @@ export function selectSegments(
       candidates = getCandidates(library, transitionTypes, ctx, 2);
     }
 
-    if (candidates.length > 0) {
+    // If library candidates are low confidence, generate a bridge dynamically
+    if (detectLowConfidence(candidates, energyTarget, 2)) {
+      const bridgingCtx: BridgingContext = {
+        previousSong: track,
+        nextSong: nextTrack,
+        stationMood: station.mood_tags,
+        stationGenre: station.genre_tags,
+      };
+      const bridged = await generateBridge(bridgingCtx, llm, tts);
+      useSegment(bridged);
+    } else if (candidates.length > 0) {
       useSegment(pickBest(candidates, rng, usageBumps));
     }
   }

--- a/packages/assembly/src/selector.ts
+++ b/packages/assembly/src/selector.ts
@@ -2,6 +2,7 @@ import type { Station, Segment, SegmentType, TimelineEntry, TracklistEntry } fro
 import {
   detectLowConfidence,
   generateBridge,
+  synthesizeBoundary,
   StubLLMProvider,
   StubTTSProvider,
   type BridgingContext,
@@ -18,6 +19,8 @@ export interface AssemblyConfig {
   variationSeed: number;
   llmProvider?: LLMProvider;
   ttsProvider?: TTSProvider;
+  /** Allow stub LLM/TTS providers. Must be true in test/dev; omit in production. */
+  allowStubs?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -155,8 +158,22 @@ export async function selectSegments(
 ): Promise<TimelineEntry[]> {
   const rng = createRng(config.variationSeed);
   const tracklist = station.tracklist;
-  const llm = config.llmProvider ?? new StubLLMProvider();
-  const tts = config.ttsProvider ?? new StubTTSProvider();
+
+  // Validate providers — stubs only allowed when explicitly opted in
+  let llm: LLMProvider;
+  let tts: TTSProvider;
+  if (config.llmProvider && config.ttsProvider) {
+    llm = config.llmProvider;
+    tts = config.ttsProvider;
+  } else if (config.allowStubs) {
+    llm = config.llmProvider ?? new StubLLMProvider();
+    tts = config.ttsProvider ?? new StubTTSProvider();
+  } else {
+    throw new Error(
+      'selectSegments requires llmProvider and ttsProvider in production. ' +
+      'Pass both providers, or set allowStubs: true for test/dev mode.',
+    );
+  }
 
   if (tracklist.length === 0) return [];
 
@@ -194,13 +211,20 @@ export async function selectSegments(
     nextTrack: tracklist[0] ?? null,
   };
 
-  // Prefer genre-matching intro, fall back to any intro
+  // Prefer genre-matching intro, fall back to any intro, synthesize if none exist
   let introCandidates = getCandidates(library, ['show_intro'], introCtx, 5);
   if (introCandidates.length === 0) {
     introCandidates = library.filter((s) => s.type === 'show_intro');
   }
   if (introCandidates.length > 0) {
     useSegment(pickBest(introCandidates, rng, usageBumps));
+  } else {
+    try {
+      const intro = await synthesizeBoundary(
+        'show_intro', station.name, station.genre_tags, station.mood_tags, tts,
+      );
+      useSegment(intro);
+    } catch { /* boundary synthesis failed — continue without intro */ }
   }
 
   // --- 2. Songs with interleaved segments ---
@@ -250,16 +274,23 @@ export async function selectSegments(
       candidates = getCandidates(library, transitionTypes, ctx, 2);
     }
 
-    // If library candidates are low confidence, generate a bridge dynamically
-    if (detectLowConfidence(candidates, energyTarget, 2)) {
+    // If library candidates are low confidence (±1 energy rule), generate a bridge
+    if (detectLowConfidence(candidates, energyTarget, 1)) {
       const bridgingCtx: BridgingContext = {
         previousSong: track,
         nextSong: nextTrack,
         stationMood: station.mood_tags,
         stationGenre: station.genre_tags,
       };
-      const bridged = await generateBridge(bridgingCtx, llm, tts);
-      useSegment(bridged);
+      try {
+        const bridged = await generateBridge(bridgingCtx, llm, tts);
+        useSegment(bridged);
+      } catch {
+        // LLM/TTS failure — fall back to best available candidate or skip
+        if (candidates.length > 0) {
+          useSegment(pickBest(candidates, rng, usageBumps));
+        }
+      }
     } else if (candidates.length > 0) {
       useSegment(pickBest(candidates, rng, usageBumps));
     }
@@ -283,6 +314,13 @@ export async function selectSegments(
   }
   if (outroCandidates.length > 0) {
     useSegment(pickBest(outroCandidates, rng, usageBumps));
+  } else {
+    try {
+      const outro = await synthesizeBoundary(
+        'show_outro', station.name, station.genre_tags, station.mood_tags, tts,
+      );
+      useSegment(outro);
+    } catch { /* boundary synthesis failed — continue without outro */ }
   }
 
   return entries;


### PR DESCRIPTION
## Summary
- Adds `bridging.ts` with `BridgingContext`, `LLMProvider`/`TTSProvider` interfaces, stub implementations, `detectLowConfidence()`, and `generateBridge()`
- Integrates bridging into `selectSegments` — when library candidates are empty, energy-mismatched, or overused, a transition segment is generated on-the-fly via pluggable LLM + TTS providers
- `selectSegments` is now async; all callers (tests, CLI) updated accordingly
- 19 new bridging tests + all 24 existing selector tests updated and passing (65 total)

## Test plan
- [x] `npx vitest run` in `packages/assembly` — 65 tests pass
- [x] `npx tsc --noEmit` — clean typecheck
- [x] Verify CLI still works end-to-end with `npm run assemble`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic generation of transition segments and show intro/outro when library candidates are inadequate; pluggable script-generation and audio-synthesis providers with optional deterministic stub providers; segment selection is now async and resilient to provider errors.

* **Tests**
  * Comprehensive tests covering bridging, synthesis, selector fallbacks, deterministic stubs, and integration scenarios.

* **Documentation**
  * Updated pipeline docs describing async selection, provider hooks, and bridging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->