### PR TITLE
feat(tools): add Station Manager UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,7 @@ Each issue should be completable in 1-3 coding sessions. If an issue takes more 
 | `feature/assembly-manifest` | PR #33 (merged) | Timeline manifest builder (`buildManifest`, `validateManifest`, `getManifestStats`) + segment selector (`selectSegments`) with all assembly rules + CLI. 46 tests |
 | `feature/assembly-bridging` | PR #34 | Dynamic bridging fallback: `BridgingContext`, `LLMProvider`/`TTSProvider` interfaces, `StubLLMProvider` (6 deterministic templates), `StubTTSProvider` (silent WAV), `detectLowConfidence()`, `generateBridge()`, `synthesizeBoundary()`. Selector generates bridge segments on-the-fly when library candidates are empty/overused/energy-mismatched. Stubs gated behind `allowStubs` flag. Error-resilient (try/catch fallback). 72 tests |
 | `feature/tools-segment-studio` | PR #35 | Segment Studio review queue UI in `apps/tools/`. Vite + React 18 + TypeScript + Tailwind CSS v4. API client (`src/api.ts`), stats bar, filter bar (type/genre/mood/quality/search), segment cards with audio player + approve/reject/regenerate actions, bulk approve, pagination. 36 tests |
+| `feature/tools-station-manager` | PR #36 | Station Manager UI: station list (grid view), station editor (create/edit with metadata form + tracklist management with up/down reordering). React Router routing, top nav bar. Station API client functions in `api.ts`. 36 tests (existing) |
 
 ### API Endpoints (from `feature/api-stations`)
 
@@ -451,7 +452,9 @@ The assembly package is now functional with segment selection, manifest building
 
 ### Tools Web App (`apps/tools/`)
 
-Vite + React 18 + TypeScript + Tailwind CSS v4. Dark theme (`#0D0D0D` bg, `#C8832A` gold accent). Dev server proxies `/api` to backend at `localhost:3001`.
+Vite + React 19 + TypeScript + Tailwind CSS v4 + React Router v7. Dark theme (`#0D0D0D` bg, `#C8832A` gold accent). Dev server proxies `/api` to backend at `localhost:3001`.
+
+**Routing** (`src/App.tsx`): React Router with `BrowserRouter` in `main.tsx`. Routes: `/stations` → StationList, `/stations/new` → StationEditor (create), `/stations/:id` → StationEditor (edit), `/segments` → SegmentStudio, `/assembly` → placeholder. Top nav bar (`src/components/NavBar.tsx`) with NavLink active states.
 
 **Segment Studio** (`src/pages/SegmentStudio.tsx`) — Review queue for voice segments:
 - Stats bar: total segments, by-type breakdown, avg quality, total duration
@@ -461,9 +464,16 @@ Vite + React 18 + TypeScript + Tailwind CSS v4. Dark theme (`#0D0D0D` bg, `#C883
 - Bulk approve: approve all pending segments above a quality threshold
 - Pagination: 20 per page, page-based navigation
 
-**API Client** (`src/api.ts`): `getSegments(filters)`, `updateSegment(id, data)`, `deleteSegment(id)`, `bulkApprove(threshold)`, `getStats()`. Base URL from `VITE_API_URL` env var or empty (proxy).
+**Station Manager** — Station list (`src/pages/StationList.tsx`) + editor (`src/pages/StationEditor.tsx`):
+- List view: grid of gold-edge cards showing name, description, genre/mood tags, published status. "Create New Station" button
+- Editor: metadata form (name, description, genre tags, mood tags), tracklist section with up/down arrow reordering and remove buttons, add-track form (artist, title, duration as m:ss, optional ISRC)
+- `canonical_id` auto-generated as `artist - title` (with `[ISRC]` suffix when provided)
+- Save creates (POST) or updates (PUT metadata + PUT tracklist). Partial create failure (metadata OK, tracks fail) navigates to created station with error
+- Publish/unpublish toggle, delete with confirmation
 
-**Not yet built:** Station Manager, Assembly Dashboard pages.
+**API Client** (`src/api.ts`): Base URL from `VITE_API_URL` env var or empty (proxy). Segments: `getSegments(filters)`, `updateSegment(id, data)`, `deleteSegment(id)`, `bulkApprove(threshold)`, `getStats()`. Stations: `getStations()`, `getStation(id)`, `createStation(data)`, `updateStation(id, data)`, `deleteStation(id)`, `addTrack(stationId, track)`, `replaceTracklist(stationId, tracks)`, `removeTrack(stationId, trackId)`.
+
+**Not yet built:** Assembly Dashboard page.
 
 ### Not yet started
 
@@ -483,6 +493,6 @@ Vite + React 18 + TypeScript + Tailwind CSS v4. Dark theme (`#0D0D0D` bg, `#C883
 
 **Phase 1: Foundation** — Set up Chatterbox, define schemas, build Segment Studio MVP, produce initial segment library (300-500 segments for hip-hop/R&B), build Station Manager MVP, build assembly pipeline MVP, deploy first test station.
 
-**Next up:** Merge pending feature branches → Segment Studio review queue built (PR #35) → build Station Manager and Assembly Dashboard pages in `apps/tools/` → produce initial segment library.
+**Next up:** Merge pending feature branches → Station Manager built (PR #36) → build Assembly Dashboard page in `apps/tools/` (#16) → produce initial segment library.
 
 **Phase 2: Mobile App** — Run v1 → v2 UI migration (`v2-migration/migrate-ui.sh`). Implement stubs against v2 backend. Priority order: Storage → AuthService → api → MusicProvider → SessionEngine/QueueManager (consume timeline manifests) → AudioCoordinator/SegmentController (segment playback). Do NOT rebuild or significantly modify the UI — implement the stub interfaces so existing screens work with the new backend.

--- a/apps/tools/README.md
+++ b/apps/tools/README.md
@@ -1,0 +1,73 @@
+# React + TypeScript + Vite
+
+This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+
+Currently, two official plugins are available:
+
+- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
+- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+
+## React Compiler
+
+The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+
+## Expanding the ESLint configuration
+
+If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+
+```js
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      // Other configs...
+
+      // Remove tseslint.configs.recommended and replace with this
+      tseslint.configs.recommendedTypeChecked,
+      // Alternatively, use this for stricter rules
+      tseslint.configs.strictTypeChecked,
+      // Optionally, add this for stylistic rules
+      tseslint.configs.stylisticTypeChecked,
+
+      // Other configs...
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+      // other options...
+    },
+  },
+])
+```
+
+You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+
+```js
+// eslint.config.js
+import reactX from 'eslint-plugin-react-x'
+import reactDom from 'eslint-plugin-react-dom'
+
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      // Other configs...
+      // Enable lint rules for React
+      reactX.configs['recommended-typescript'],
+      // Enable lint rules for React DOM
+      reactDom.configs.recommended,
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+      // other options...
+    },
+  },
+])
+```

--- a/apps/tools/package.json
+++ b/apps/tools/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "react-router-dom": "^7.13.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/apps/tools/src/App.tsx
+++ b/apps/tools/src/App.tsx
@@ -1,7 +1,32 @@
+import { Routes, Route, Navigate } from 'react-router-dom'
+import { NavBar } from './components/NavBar'
 import { SegmentStudio } from './pages/SegmentStudio'
+import { StationList } from './pages/StationList'
+import { StationEditor } from './pages/StationEditor'
 
 function App() {
-  return <SegmentStudio />
+  return (
+    <div className="min-h-screen">
+      <NavBar />
+      <Routes>
+        <Route path="/" element={<Navigate to="/stations" replace />} />
+        <Route path="/stations" element={<StationList />} />
+        <Route path="/stations/new" element={<StationEditor />} />
+        <Route path="/stations/:id" element={<StationEditor />} />
+        <Route path="/segments" element={<SegmentStudio />} />
+        <Route path="/assembly" element={<AssemblyPlaceholder />} />
+      </Routes>
+    </div>
+  )
+}
+
+function AssemblyPlaceholder() {
+  return (
+    <div className="p-8 text-center">
+      <h1 className="text-xl font-semibold text-onay-text mb-2">Assembly Dashboard</h1>
+      <p className="text-sm text-onay-muted">Coming soon — issue #16</p>
+    </div>
+  )
 }
 
 export default App

--- a/apps/tools/src/api.ts
+++ b/apps/tools/src/api.ts
@@ -117,3 +117,122 @@ export async function bulkApprove(threshold: number): Promise<BulkApproveRespons
 export async function getStats(): Promise<LibraryStats> {
   return request<LibraryStats>('/api/segments/stats');
 }
+
+// --- Station types ---
+
+export interface Station {
+  station_id: string;
+  name: string;
+  description: string | null;
+  genre_tags: string[];
+  mood_tags: string[];
+  cover_art_url: string | null;
+  rotation_schedule: Record<string, unknown> | null;
+  is_published: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface StationWithTracklist extends Station {
+  tracklist: Track[];
+}
+
+export interface Track {
+  id: string;
+  canonical_id: string;
+  artist: string;
+  title: string;
+  isrc: string | null;
+  duration_ms: number;
+  position: number;
+  apple_music_id: string | null;
+  spotify_id: string | null;
+}
+
+export interface CreateStationData {
+  name: string;
+  description?: string;
+  genre_tags?: string[];
+  mood_tags?: string[];
+  cover_art_url?: string;
+}
+
+export interface UpdateStationData {
+  name?: string;
+  description?: string | null;
+  genre_tags?: string[];
+  mood_tags?: string[];
+  cover_art_url?: string;
+  is_published?: boolean;
+}
+
+export interface AddTrackData {
+  canonical_id: string;
+  artist: string;
+  title: string;
+  duration_ms: number;
+  isrc?: string;
+}
+
+export interface ReplaceTrackData {
+  canonical_id: string;
+  artist: string;
+  title: string;
+  duration_ms: number;
+  isrc?: string;
+}
+
+// --- Station API ---
+
+export async function getStations(): Promise<Station[]> {
+  return request<Station[]>('/api/stations');
+}
+
+export async function getStation(id: string): Promise<StationWithTracklist> {
+  return request<StationWithTracklist>(`/api/stations/${encodeURIComponent(id)}`);
+}
+
+export async function createStation(data: CreateStationData): Promise<Station> {
+  return request<Station>('/api/stations', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateStation(id: string, data: UpdateStationData): Promise<Station> {
+  return request<Station>(`/api/stations/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteStation(id: string): Promise<void> {
+  return request<void>(`/api/stations/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function addTrack(stationId: string, track: AddTrackData): Promise<Track> {
+  return request<Track>(`/api/stations/${encodeURIComponent(stationId)}/tracks`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(track),
+  });
+}
+
+export async function replaceTracklist(stationId: string, tracks: ReplaceTrackData[]): Promise<Track[]> {
+  return request<Track[]>(`/api/stations/${encodeURIComponent(stationId)}/tracks`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(tracks),
+  });
+}
+
+export async function removeTrack(stationId: string, trackId: string): Promise<void> {
+  return request<void>(
+    `/api/stations/${encodeURIComponent(stationId)}/tracks/${encodeURIComponent(trackId)}`,
+    { method: 'DELETE' },
+  );
+}

--- a/apps/tools/src/components/NavBar.tsx
+++ b/apps/tools/src/components/NavBar.tsx
@@ -1,0 +1,34 @@
+import { NavLink } from 'react-router-dom';
+
+const links = [
+  { to: '/stations', label: 'Stations' },
+  { to: '/segments', label: 'Segments' },
+  { to: '/assembly', label: 'Assembly' },
+];
+
+export function NavBar() {
+  return (
+    <nav className="flex items-center gap-6 px-4 py-3 border-b border-onay-border bg-onay-card">
+      <span className="text-sm font-semibold text-onay-gold tracking-wider uppercase">
+        Onay Tools
+      </span>
+      <div className="flex gap-1">
+        {links.map((link) => (
+          <NavLink
+            key={link.to}
+            to={link.to}
+            className={({ isActive }) =>
+              `px-3 py-1.5 text-sm rounded ${
+                isActive
+                  ? 'bg-onay-gold/20 text-onay-gold border border-onay-gold/40'
+                  : 'text-onay-muted hover:text-onay-text'
+              }`
+            }
+          >
+            {link.label}
+          </NavLink>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/apps/tools/src/main.tsx
+++ b/apps/tools/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/apps/tools/src/pages/StationEditor.tsx
+++ b/apps/tools/src/pages/StationEditor.tsx
@@ -147,7 +147,14 @@ export function StationEditor() {
         });
         // Save tracks if any were added
         if (tracks.length > 0) {
-          await replaceTracklist(station.station_id, tracks.map(trackToReplaceData));
+          try {
+            await replaceTracklist(station.station_id, tracks.map(trackToReplaceData));
+          } catch (err) {
+            // Station was created but tracks failed — navigate to it so user can retry
+            setError(err instanceof Error ? err.message : 'Station created but failed to save tracks');
+            navigate(`/stations/${station.station_id}`, { replace: true });
+            return;
+          }
         }
         navigate(`/stations/${station.station_id}`, { replace: true });
       } else {
@@ -361,7 +368,7 @@ export function StationEditor() {
                   onClick={() => moveTrack(i, -1)}
                   disabled={i === 0}
                   className="w-6 h-6 text-xs rounded border border-onay-border text-onay-muted hover:text-onay-text disabled:opacity-20"
-                  title="Move up"
+                  aria-label={`Move ${track.artist} — ${track.title} up`}
                 >
                   &#9650;
                 </button>
@@ -369,14 +376,14 @@ export function StationEditor() {
                   onClick={() => moveTrack(i, 1)}
                   disabled={i === tracks.length - 1}
                   className="w-6 h-6 text-xs rounded border border-onay-border text-onay-muted hover:text-onay-text disabled:opacity-20"
-                  title="Move down"
+                  aria-label={`Move ${track.artist} — ${track.title} down`}
                 >
                   &#9660;
                 </button>
                 <button
                   onClick={() => removeTrackAt(i)}
                   className="w-6 h-6 text-xs rounded border border-red-700 text-red-400 hover:bg-red-900/40"
-                  title="Remove"
+                  aria-label={`Remove ${track.artist} — ${track.title}`}
                 >
                   &#10005;
                 </button>

--- a/apps/tools/src/pages/StationEditor.tsx
+++ b/apps/tools/src/pages/StationEditor.tsx
@@ -1,0 +1,464 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  getStation,
+  createStation,
+  updateStation,
+  deleteStation,
+  replaceTracklist,
+  type StationWithTracklist,
+  type Track,
+  type ReplaceTrackData,
+} from '../api';
+
+interface TrackDraft {
+  key: string;
+  canonical_id: string;
+  artist: string;
+  title: string;
+  duration_ms: number;
+  isrc: string;
+  // present on tracks loaded from the server
+  id?: string;
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function parseDuration(str: string): number | null {
+  const parts = str.split(':');
+  if (parts.length === 2) {
+    const m = parseInt(parts[0], 10);
+    const s = parseInt(parts[1], 10);
+    if (!isNaN(m) && !isNaN(s)) return (m * 60 + s) * 1000;
+  }
+  const ms = parseInt(str, 10);
+  if (!isNaN(ms) && ms > 0) return ms;
+  return null;
+}
+
+function generateCanonicalId(artist: string, title: string, isrc?: string): string {
+  const base = `${artist.toLowerCase()} - ${title.toLowerCase()}`;
+  return isrc ? `${base} [${isrc.toUpperCase()}]` : base;
+}
+
+function trackToReplaceData(t: TrackDraft): ReplaceTrackData {
+  return {
+    canonical_id: t.canonical_id,
+    artist: t.artist,
+    title: t.title,
+    duration_ms: t.duration_ms,
+    ...(t.isrc ? { isrc: t.isrc } : {}),
+  };
+}
+
+let keyCounter = 0;
+function nextKey(): string {
+  return `track-${++keyCounter}`;
+}
+
+function serverTrackToDraft(t: Track): TrackDraft {
+  return {
+    key: nextKey(),
+    id: t.id,
+    canonical_id: t.canonical_id,
+    artist: t.artist,
+    title: t.title,
+    duration_ms: t.duration_ms,
+    isrc: t.isrc ?? '',
+  };
+}
+
+export function StationEditor() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isCreate = !id;
+
+  // Station metadata
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [genreTags, setGenreTags] = useState('');
+  const [moodTags, setMoodTags] = useState('');
+  const [isPublished, setIsPublished] = useState(false);
+
+  // Tracklist
+  const [tracks, setTracks] = useState<TrackDraft[]>([]);
+
+  // Add-track form
+  const [newArtist, setNewArtist] = useState('');
+  const [newTitle, setNewTitle] = useState('');
+  const [newDuration, setNewDuration] = useState('');
+  const [newIsrc, setNewIsrc] = useState('');
+
+  // UI state
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadStation = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const station: StationWithTracklist = await getStation(id);
+      setName(station.name);
+      setDescription(station.description ?? '');
+      setGenreTags(station.genre_tags.join(', '));
+      setMoodTags(station.mood_tags.join(', '));
+      setIsPublished(station.is_published);
+      setTracks(station.tracklist.map(serverTrackToDraft));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load station');
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    loadStation();
+  }, [loadStation]);
+
+  function parseTags(input: string): string[] {
+    return input
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+  }
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      setError('Station name is required');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      if (isCreate) {
+        const station = await createStation({
+          name: name.trim(),
+          description: description.trim() || undefined,
+          genre_tags: parseTags(genreTags),
+          mood_tags: parseTags(moodTags),
+        });
+        // Save tracks if any were added
+        if (tracks.length > 0) {
+          await replaceTracklist(station.station_id, tracks.map(trackToReplaceData));
+        }
+        navigate(`/stations/${station.station_id}`, { replace: true });
+      } else {
+        await updateStation(id, {
+          name: name.trim(),
+          description: description.trim() || null,
+          genre_tags: parseTags(genreTags),
+          mood_tags: parseTags(moodTags),
+          is_published: isPublished,
+        });
+        await replaceTracklist(id, tracks.map(trackToReplaceData));
+        // Reload to sync server state
+        await loadStation();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save station');
+      if (!isCreate) await loadStation();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!id) return;
+    if (!window.confirm('Delete this station? This cannot be undone.')) return;
+
+    setSaving(true);
+    try {
+      await deleteStation(id);
+      navigate('/stations', { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete station');
+      setSaving(false);
+    }
+  };
+
+  const handlePublishToggle = async () => {
+    if (!id) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateStation(id, { is_published: !isPublished });
+      setIsPublished(updated.is_published);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update publish status');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAddTrack = () => {
+    if (!newArtist.trim() || !newTitle.trim() || !newDuration.trim()) return;
+    const durationMs = parseDuration(newDuration.trim());
+    if (!durationMs) {
+      setError('Duration must be m:ss or milliseconds');
+      return;
+    }
+    setTracks((prev) => [
+      ...prev,
+      {
+        key: nextKey(),
+        canonical_id: generateCanonicalId(newArtist.trim(), newTitle.trim(), newIsrc.trim() || undefined),
+        artist: newArtist.trim(),
+        title: newTitle.trim(),
+        duration_ms: durationMs,
+        isrc: newIsrc.trim(),
+      },
+    ]);
+    setNewArtist('');
+    setNewTitle('');
+    setNewDuration('');
+    setNewIsrc('');
+    setError(null);
+  };
+
+  const moveTrack = (index: number, direction: -1 | 1) => {
+    const target = index + direction;
+    if (target < 0 || target >= tracks.length) return;
+    setTracks((prev) => {
+      const next = [...prev];
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  };
+
+  const removeTrackAt = (index: number) => {
+    setTracks((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  if (loading) {
+    return <p className="p-4 text-onay-muted text-sm">Loading...</p>;
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b border-onay-border">
+        <div>
+          <h1 className="text-xl font-semibold text-onay-text">
+            {isCreate ? 'Create Station' : 'Edit Station'}
+          </h1>
+          <p className="text-sm text-onay-muted">
+            {isCreate ? 'Set up a new radio station' : name}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {!isCreate && (
+            <>
+              <button
+                onClick={handlePublishToggle}
+                disabled={saving}
+                className={`px-3 py-1.5 text-sm rounded border disabled:opacity-50 ${
+                  isPublished
+                    ? 'bg-green-900/40 text-green-400 border-green-700 hover:bg-green-900/60'
+                    : 'bg-onay-card text-onay-muted border-onay-border hover:text-onay-text'
+                }`}
+              >
+                {isPublished ? 'Published' : 'Draft'}
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={saving}
+                className="px-3 py-1.5 text-sm rounded bg-red-900/40 text-red-400 border border-red-700 hover:bg-red-900/60 disabled:opacity-50"
+              >
+                Delete
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="p-4 text-red-400 text-sm">Error: {error}</div>
+      )}
+
+      {/* Metadata Form */}
+      <div className="p-4 space-y-4 border-b border-onay-border">
+        <div>
+          <label className="block text-xs text-onay-muted uppercase tracking-wider mb-1">Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Station name"
+            className="w-full bg-onay-card border border-onay-border text-onay-text rounded px-3 py-2 text-sm focus:border-onay-gold outline-none"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-onay-muted uppercase tracking-wider mb-1">Description</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What's this station about?"
+            rows={3}
+            className="w-full bg-onay-card border border-onay-border text-onay-text rounded px-3 py-2 text-sm resize-y focus:border-onay-gold outline-none"
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-xs text-onay-muted uppercase tracking-wider mb-1">Genre Tags</label>
+            <input
+              type="text"
+              value={genreTags}
+              onChange={(e) => setGenreTags(e.target.value)}
+              placeholder="hip-hop, r&b, soul"
+              className="w-full bg-onay-card border border-onay-border text-onay-text rounded px-3 py-2 text-sm focus:border-onay-gold outline-none"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-onay-muted uppercase tracking-wider mb-1">Mood Tags</label>
+            <input
+              type="text"
+              value={moodTags}
+              onChange={(e) => setMoodTags(e.target.value)}
+              placeholder="chill, late-night, vibes"
+              className="w-full bg-onay-card border border-onay-border text-onay-text rounded px-3 py-2 text-sm focus:border-onay-gold outline-none"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Tracklist */}
+      <div className="p-4">
+        <h2 className="text-sm font-semibold text-onay-text mb-3">
+          Tracklist
+          {tracks.length > 0 && (
+            <span className="text-onay-muted font-normal ml-2">({tracks.length} tracks)</span>
+          )}
+        </h2>
+
+        {tracks.length === 0 && (
+          <p className="text-xs text-onay-muted mb-4">No tracks yet. Add tracks below.</p>
+        )}
+
+        {/* Track rows */}
+        <div className="space-y-1 mb-4">
+          {tracks.map((track, i) => (
+            <div
+              key={track.key}
+              className="flex items-center gap-2 border-l-2 border-l-onay-gold border border-onay-border rounded bg-onay-card px-3 py-2"
+            >
+              <span className="text-xs text-onay-muted w-6 shrink-0 text-right">{i + 1}</span>
+              <div className="flex-1 min-w-0">
+                <span className="text-sm text-onay-text">{track.artist}</span>
+                <span className="text-onay-muted mx-1.5">&mdash;</span>
+                <span className="text-sm text-onay-text/80">{track.title}</span>
+              </div>
+              <span className="text-xs text-onay-muted shrink-0">{formatDuration(track.duration_ms)}</span>
+              <div className="flex gap-1 shrink-0">
+                <button
+                  onClick={() => moveTrack(i, -1)}
+                  disabled={i === 0}
+                  className="w-6 h-6 text-xs rounded border border-onay-border text-onay-muted hover:text-onay-text disabled:opacity-20"
+                  title="Move up"
+                >
+                  &#9650;
+                </button>
+                <button
+                  onClick={() => moveTrack(i, 1)}
+                  disabled={i === tracks.length - 1}
+                  className="w-6 h-6 text-xs rounded border border-onay-border text-onay-muted hover:text-onay-text disabled:opacity-20"
+                  title="Move down"
+                >
+                  &#9660;
+                </button>
+                <button
+                  onClick={() => removeTrackAt(i)}
+                  className="w-6 h-6 text-xs rounded border border-red-700 text-red-400 hover:bg-red-900/40"
+                  title="Remove"
+                >
+                  &#10005;
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Add Track Form */}
+        <div className="border border-onay-border rounded bg-onay-card p-3">
+          <h3 className="text-xs text-onay-muted uppercase tracking-wider mb-2">Add Track</h3>
+          <div className="grid grid-cols-[1fr_1fr_auto_auto] gap-2 items-end">
+            <div>
+              <label className="block text-xs text-onay-muted mb-1">Artist</label>
+              <input
+                type="text"
+                value={newArtist}
+                onChange={(e) => setNewArtist(e.target.value)}
+                placeholder="Artist name"
+                className="w-full bg-onay-bg border border-onay-border text-onay-text rounded px-2 py-1.5 text-sm focus:border-onay-gold outline-none"
+                onKeyDown={(e) => e.key === 'Enter' && handleAddTrack()}
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-onay-muted mb-1">Title</label>
+              <input
+                type="text"
+                value={newTitle}
+                onChange={(e) => setNewTitle(e.target.value)}
+                placeholder="Track title"
+                className="w-full bg-onay-bg border border-onay-border text-onay-text rounded px-2 py-1.5 text-sm focus:border-onay-gold outline-none"
+                onKeyDown={(e) => e.key === 'Enter' && handleAddTrack()}
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-onay-muted mb-1">Duration</label>
+              <input
+                type="text"
+                value={newDuration}
+                onChange={(e) => setNewDuration(e.target.value)}
+                placeholder="3:45"
+                className="w-24 bg-onay-bg border border-onay-border text-onay-text rounded px-2 py-1.5 text-sm focus:border-onay-gold outline-none"
+                onKeyDown={(e) => e.key === 'Enter' && handleAddTrack()}
+              />
+            </div>
+            <button
+              onClick={handleAddTrack}
+              className="px-3 py-1.5 text-sm rounded bg-onay-gold/20 text-onay-gold border border-onay-gold/40 hover:bg-onay-gold/30"
+            >
+              Add
+            </button>
+          </div>
+          <div className="mt-2">
+            <label className="block text-xs text-onay-muted mb-1">ISRC (optional)</label>
+            <input
+              type="text"
+              value={newIsrc}
+              onChange={(e) => setNewIsrc(e.target.value)}
+              placeholder="e.g. USRC12345678"
+              className="w-64 bg-onay-bg border border-onay-border text-onay-text rounded px-2 py-1.5 text-sm focus:border-onay-gold outline-none"
+              onKeyDown={(e) => e.key === 'Enter' && handleAddTrack()}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Save bar */}
+      <div className="sticky bottom-0 flex items-center gap-3 p-4 border-t border-onay-border bg-onay-bg">
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="px-4 py-2 text-sm rounded bg-onay-gold/20 text-onay-gold border border-onay-gold/40 hover:bg-onay-gold/30 disabled:opacity-50"
+        >
+          {saving ? 'Saving...' : isCreate ? 'Create Station' : 'Save Changes'}
+        </button>
+        <button
+          onClick={() => navigate('/stations')}
+          className="px-4 py-2 text-sm rounded border border-onay-border text-onay-muted hover:text-onay-text"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/tools/src/pages/StationList.tsx
+++ b/apps/tools/src/pages/StationList.tsx
@@ -1,0 +1,101 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { getStations, type Station } from '../api';
+
+export function StationList() {
+  const [stations, setStations] = useState<Station[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStations = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setStations(await getStations());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch stations');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStations();
+  }, [fetchStations]);
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b border-onay-border">
+        <div>
+          <h1 className="text-xl font-semibold text-onay-text">Stations</h1>
+          <p className="text-sm text-onay-muted">Manage radio stations and tracklists</p>
+        </div>
+        <Link
+          to="/stations/new"
+          className="px-4 py-2 text-sm rounded bg-onay-gold/20 text-onay-gold border border-onay-gold/40 hover:bg-onay-gold/30"
+        >
+          Create New Station
+        </Link>
+      </div>
+
+      {error && (
+        <div className="p-4 text-red-400 text-sm">Error: {error}</div>
+      )}
+
+      {loading && stations.length === 0 && (
+        <p className="p-4 text-onay-muted text-sm">Loading...</p>
+      )}
+
+      {!loading && stations.length === 0 && !error && (
+        <p className="p-4 text-onay-muted text-sm">No stations yet. Create one to get started.</p>
+      )}
+
+      {/* Station Grid */}
+      <div className="p-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {stations.map((station) => (
+          <StationCard key={station.station_id} station={station} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StationCard({ station }: { station: Station }) {
+  return (
+    <Link
+      to={`/stations/${station.station_id}`}
+      className="block border-l-2 border-l-onay-gold border border-onay-border rounded bg-onay-card p-4 hover:border-onay-gold/60 transition-colors"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <h2 className="text-sm font-semibold text-onay-text truncate">{station.name}</h2>
+        {station.is_published ? (
+          <span className="text-xs px-2 py-0.5 rounded border bg-green-900/50 text-green-400 border-green-700 shrink-0">
+            Published
+          </span>
+        ) : (
+          <span className="text-xs px-2 py-0.5 rounded border bg-onay-card text-onay-muted border-onay-border shrink-0">
+            Draft
+          </span>
+        )}
+      </div>
+
+      {station.description && (
+        <p className="text-xs text-onay-muted mb-3 line-clamp-2">{station.description}</p>
+      )}
+
+      <div className="flex flex-wrap gap-1.5">
+        {station.genre_tags.map((tag) => (
+          <span key={`g-${tag}`} className="text-xs px-1.5 py-0.5 rounded bg-onay-bg border border-onay-border text-onay-muted">
+            {tag}
+          </span>
+        ))}
+        {station.mood_tags.map((tag) => (
+          <span key={`m-${tag}`} className="text-xs px-1.5 py-0.5 rounded bg-onay-bg border border-onay-border text-onay-gold/70">
+            {tag}
+          </span>
+        ))}
+      </div>
+    </Link>
+  );
+}

--- a/apps/tools/vite.config.ts
+++ b/apps/tools/vite.config.ts
@@ -7,7 +7,10 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:3001',
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
     },
   },
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1256,7 +1256,8 @@
       "version": "0.1.0",
       "dependencies": {
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^7.13.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -13640,6 +13641,57 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
+      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
+      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -14165,6 +14217,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/setprototypeof": {


### PR DESCRIPTION
## Summary
- Add Station Manager pages to the tools web app: list view (grid of station cards) and editor (create/edit with metadata form + tracklist management)
- Set up React Router with top nav bar for navigating between Stations, Segments, and Assembly
- Add 8 station/track API client functions to `api.ts` with full TypeScript types

## Test plan
- [x] `npm run test` passes (36 existing tests still green)
- [x] `tsc --noEmit` compiles cleanly
- [x] Navigate to `/stations` — shows station list (empty state if no stations)
- [x] Click "Create New Station" — form renders, fill in name/tags/tracks, save creates station and redirects
- [x] Click a station card — editor loads with existing data, edit metadata and tracklist, save persists
- [x] Tracklist reordering (up/down arrows) and remove works
- [x] Publish/unpublish toggle updates status
- [x] Delete with confirmation removes station and navigates back to list
- [x] Top nav links switch between Stations, Segments, and Assembly pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide client-side routing with route structure for Stations, Segments, and a new Assembly dashboard placeholder
  * Navigation bar for switching between Stations, Segments, and Assembly
  * Stations: list view, create/edit/delete flows, metadata editing, tracklist management (add/reorder/remove), and publish/unpublish controls
  * Station cards show name, tags, and published/draft status

* **Documentation**
  * Added Tools app setup and linting guidance (React + TypeScript + Vite)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->