### PR TITLE
feat(tools): add Assembly Dashboard UI and assembly endpoint

### DIFF
--- a/apps/tools/src/App.tsx
+++ b/apps/tools/src/App.tsx
@@ -3,6 +3,7 @@ import { NavBar } from './components/NavBar'
 import { SegmentStudio } from './pages/SegmentStudio'
 import { StationList } from './pages/StationList'
 import { StationEditor } from './pages/StationEditor'
+import { AssemblyDashboard } from './pages/AssemblyDashboard'
 
 function App() {
   return (
@@ -14,17 +15,8 @@ function App() {
         <Route path="/stations/new" element={<StationEditor />} />
         <Route path="/stations/:id" element={<StationEditor />} />
         <Route path="/segments" element={<SegmentStudio />} />
-        <Route path="/assembly" element={<AssemblyPlaceholder />} />
+        <Route path="/assembly" element={<AssemblyDashboard />} />
       </Routes>
-    </div>
-  )
-}
-
-function AssemblyPlaceholder() {
-  return (
-    <div className="p-8 text-center">
-      <h1 className="text-xl font-semibold text-onay-text mb-2">Assembly Dashboard</h1>
-      <p className="text-sm text-onay-muted">Coming soon — issue #16</p>
     </div>
   )
 }

--- a/apps/tools/src/__tests__/AssemblyDashboard.test.tsx
+++ b/apps/tools/src/__tests__/AssemblyDashboard.test.tsx
@@ -1,0 +1,400 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AssemblyDashboard } from '../pages/AssemblyDashboard';
+import type { Station, Timeline, TimelineHistoryItem, AssembleResult } from '../api';
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+function makeStation(overrides: Partial<Station> = {}): Station {
+  return {
+    station_id: 'station-1',
+    name: 'Hip-Hop Vibes',
+    description: 'A hip-hop station',
+    genre_tags: ['hip-hop'],
+    mood_tags: ['chill'],
+    cover_art_url: null,
+    rotation_schedule: null,
+    is_published: true,
+    created_at: '2026-03-01T00:00:00Z',
+    updated_at: '2026-03-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeTimeline(overrides: Partial<Timeline> = {}): Timeline {
+  return {
+    id: 'timeline-1',
+    station_id: 'station-1',
+    created_at: '2026-03-15T12:00:00Z',
+    entries: [
+      { type: 'segment', segment_id: 'SEG-SI-001', audio_url: '/audio/intro.wav', duration_ms: 10000 },
+      { type: 'song', canonical_id: 'sza-kill-bill', artist: 'SZA', title: 'Kill Bill', duration_ms: 180000 },
+      { type: 'segment', segment_id: 'SEG-TR-001', audio_url: '/audio/trans.wav', duration_ms: 6000 },
+      { type: 'song', canonical_id: 'frank-ivy', artist: 'Frank Ocean', title: 'Ivy', duration_ms: 240000 },
+      { type: 'segment', segment_id: 'SEG-SO-001', audio_url: '/audio/outro.wav', duration_ms: 8000 },
+    ],
+    ...overrides,
+  };
+}
+
+function makeHistoryItem(overrides: Partial<TimelineHistoryItem> = {}): TimelineHistoryItem {
+  return {
+    id: 'timeline-1',
+    created_at: '2026-03-15T12:00:00Z',
+    entry_count: 5,
+    total_duration_ms: 444000,
+    ...overrides,
+  };
+}
+
+function makeAssembleResult(): AssembleResult {
+  const tl = makeTimeline();
+  return {
+    ...tl,
+    stats: {
+      total_duration_ms: 444000,
+      song_count: 2,
+      segment_count: 3,
+      segment_ratio: 0.67,
+    },
+  };
+}
+
+// Helper to set up fetch responses in order
+function setupFetch(...responses: Array<{ status?: number; body: unknown }>) {
+  for (const resp of responses) {
+    mockFetch.mockResolvedValueOnce({
+      ok: (resp.status ?? 200) < 400,
+      status: resp.status ?? 200,
+      json: () => Promise.resolve(resp.body),
+    });
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter>
+      <AssemblyDashboard />
+    </MemoryRouter>,
+  );
+}
+
+describe('AssemblyDashboard', () => {
+  it('loads and displays station selector', async () => {
+    setupFetch({ body: [makeStation()] });
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Hip-Hop Vibes')).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText('Select station')).toBeInTheDocument();
+    expect(screen.getByText('Assembly Dashboard')).toBeInTheDocument();
+  });
+
+  it('shows placeholder when no station selected', async () => {
+    setupFetch({ body: [makeStation()] });
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Hip-Hop Vibes')).toBeInTheDocument();
+    });
+
+    // Assemble button should be disabled
+    expect(screen.getByText('Assemble')).toBeDisabled();
+  });
+
+  it('loads timeline when station is selected', async () => {
+    const stations = [makeStation()];
+    const timeline = makeTimeline();
+    const history = [makeHistoryItem()];
+
+    setupFetch(
+      { body: stations },           // getStations
+      { body: timeline },            // getTimeline
+      { body: history },             // getTimelineHistory
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Hip-Hop Vibes')).toBeInTheDocument();
+    });
+
+    // Select the station
+    fireEvent.change(screen.getByLabelText('Select station'), {
+      target: { value: 'station-1' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Kill Bill')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('SZA')).toBeInTheDocument();
+    expect(screen.getByText('Frank Ocean')).toBeInTheDocument();
+    expect(screen.getByText('2 songs')).toBeInTheDocument();
+    expect(screen.getByText('3 segments')).toBeInTheDocument();
+  });
+
+  it('shows no-timeline message when station has no timeline', async () => {
+    setupFetch(
+      { body: [makeStation()] },
+      { status: 404, body: { error: 'No timeline found' } },
+      { body: [] },
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Hip-Hop Vibes')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Select station'), {
+      target: { value: 'station-1' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No timeline yet/)).toBeInTheDocument();
+    });
+  });
+
+  it('triggers assembly and shows result', async () => {
+    const result = makeAssembleResult();
+
+    setupFetch(
+      { body: [makeStation()] },                               // getStations
+      { status: 404, body: { error: 'No timeline' } },         // getTimeline (none yet)
+      { body: [] },                                              // getTimelineHistory
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Hip-Hop Vibes')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Select station'), {
+      target: { value: 'station-1' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No timeline yet/)).toBeInTheDocument();
+    });
+
+    // Now set up assembly response
+    setupFetch(
+      { status: 201, body: result },  // triggerAssembly
+      { body: [makeHistoryItem()] },   // getTimelineHistory refresh
+    );
+
+    fireEvent.click(screen.getByText('Assemble'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Assembly complete/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Kill Bill')).toBeInTheDocument();
+
+    // Verify POST was called
+    const assembleCalls = mockFetch.mock.calls.filter(
+      (c: [string, RequestInit?]) => c[0].includes('/assemble'),
+    );
+    expect(assembleCalls).toHaveLength(1);
+    expect(assembleCalls[0][1]?.method).toBe('POST');
+  });
+
+  it('shows error when assembly fails', async () => {
+    setupFetch(
+      { body: [makeStation()] },
+      { status: 404, body: { error: 'No timeline' } },
+      { body: [] },
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Hip-Hop Vibes')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Select station'), {
+      target: { value: 'station-1' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No timeline yet/)).toBeInTheDocument();
+    });
+
+    setupFetch({ status: 400, body: { error: 'Station has no tracks' } });
+
+    fireEvent.click(screen.getByText('Assemble'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Station has no tracks')).toBeInTheDocument();
+    });
+  });
+
+  it('shows history and allows viewing a past timeline', async () => {
+    const currentTimeline = makeTimeline();
+    const historyItems = [
+      makeHistoryItem({ id: 'timeline-1' }),
+      makeHistoryItem({ id: 'timeline-old', created_at: '2026-03-10T08:00:00Z', entry_count: 3, total_duration_ms: 300000 }),
+    ];
+
+    setupFetch(
+      { body: [makeStation()] },
+      { body: currentTimeline },
+      { body: historyItems },
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Hip-Hop Vibes')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Select station'), {
+      target: { value: 'station-1' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Kill Bill')).toBeInTheDocument();
+    });
+
+    // Expand history
+    fireEvent.click(screen.getByText(/History/));
+
+    // Should see history items
+    await waitFor(() => {
+      expect(screen.getByText('3 entries')).toBeInTheDocument();
+    });
+
+    // Click old timeline
+    const oldTimeline = makeTimeline({
+      id: 'timeline-old',
+      entries: [
+        { type: 'segment', segment_id: 'SEG-SI-002', audio_url: '/audio/intro2.wav', duration_ms: 9000 },
+        { type: 'song', canonical_id: 'drake-god', artist: 'Drake', title: "God's Plan", duration_ms: 200000 },
+        { type: 'segment', segment_id: 'SEG-SO-002', audio_url: '/audio/outro2.wav', duration_ms: 7000 },
+      ],
+    });
+
+    setupFetch({ body: oldTimeline });
+
+    // Find and click the old timeline button
+    const historyButtons = screen.getAllByRole('button').filter(
+      (b) => b.textContent?.includes('3 entries'),
+    );
+    fireEvent.click(historyButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("God's Plan")).toBeInTheDocument();
+    });
+
+    // Back to current button should be visible
+    expect(screen.getByText(/Back to current/)).toBeInTheDocument();
+  });
+
+  it('shows segment type badge in segment blocks', async () => {
+    setupFetch(
+      { body: [makeStation()] },
+      { body: makeTimeline() },
+      { body: [makeHistoryItem()] },
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Hip-Hop Vibes')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Select station'), {
+      target: { value: 'station-1' },
+    });
+
+    await waitFor(() => {
+      // Segment IDs shown as badge text
+      expect(screen.getByText('SEG-SI-001')).toBeInTheDocument();
+      expect(screen.getByText('SEG-TR-001')).toBeInTheDocument();
+      expect(screen.getByText('SEG-SO-001')).toBeInTheDocument();
+    });
+  });
+
+  it('shows loading state while stations load', () => {
+    // Don't resolve the fetch
+    mockFetch.mockReturnValueOnce(new Promise(() => {}));
+
+    renderDashboard();
+
+    expect(screen.getByText('Loading stations...')).toBeInTheDocument();
+  });
+
+  it('disables assemble button while assembling', async () => {
+    setupFetch(
+      { body: [makeStation()] },
+      { status: 404, body: { error: 'No timeline' } },
+      { body: [] },
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Hip-Hop Vibes')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Select station'), {
+      target: { value: 'station-1' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No timeline yet/)).toBeInTheDocument();
+    });
+
+    // Make assembly hang
+    mockFetch.mockReturnValueOnce(new Promise(() => {}));
+
+    fireEvent.click(screen.getByText('Assemble'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Assembling...')).toBeInTheDocument();
+      expect(screen.getByText('Assembling...')).toBeDisabled();
+    });
+  });
+
+  it('formats durations correctly in timeline entries', async () => {
+    const timeline = makeTimeline({
+      entries: [
+        { type: 'segment', segment_id: 'SEG-SI-001', audio_url: '/audio/x.wav', duration_ms: 65000 },
+        { type: 'song', canonical_id: 'test-song', artist: 'Test', title: 'Song', duration_ms: 3661000 },
+      ],
+    });
+
+    setupFetch(
+      { body: [makeStation()] },
+      { body: timeline },
+      { body: [] },
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Hip-Hop Vibes')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Select station'), {
+      target: { value: 'station-1' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('1:05')).toBeInTheDocument();  // 65s
+      expect(screen.getByText('61:01')).toBeInTheDocument();  // 3661s
+    });
+  });
+});

--- a/apps/tools/src/__tests__/api.test.ts
+++ b/apps/tools/src/__tests__/api.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getSegments, updateSegment, deleteSegment, bulkApprove, getStats } from '../api';
+import {
+  getSegments, updateSegment, deleteSegment, bulkApprove, getStats,
+  getTimeline, getTimelineHistory, getTimelineById, triggerAssembly,
+} from '../api';
 
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;
@@ -111,6 +114,76 @@ describe('api client', () => {
 
       expect(mockFetch).toHaveBeenCalledWith('/api/segments/stats', undefined);
       expect(result).toEqual(stats);
+    });
+  });
+
+  describe('getTimeline', () => {
+    it('fetches current timeline for station', async () => {
+      const timeline = { id: 'tl-1', station_id: 's-1', created_at: '2026-03-01', entries: [] };
+      mockFetch.mockResolvedValueOnce(jsonResponse(timeline));
+
+      const result = await getTimeline('s-1');
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/stations/s-1/timeline', undefined);
+      expect(result).toEqual(timeline);
+    });
+
+    it('encodes station ID', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: 'tl-1', entries: [] }));
+
+      await getTimeline('s/1');
+
+      expect(mockFetch.mock.calls[0][0]).toBe('/api/stations/s%2F1/timeline');
+    });
+  });
+
+  describe('getTimelineHistory', () => {
+    it('fetches history with limit', async () => {
+      const history = [{ id: 'tl-1', created_at: '2026-03-01', entry_count: 5, total_duration_ms: 100000 }];
+      mockFetch.mockResolvedValueOnce(jsonResponse(history));
+
+      const result = await getTimelineHistory('s-1', 10);
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('/api/stations/s-1/timeline/history');
+      expect(url).toContain('limit=10');
+      expect(result).toEqual(history);
+    });
+
+    it('omits limit when not provided', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse([]));
+
+      await getTimelineHistory('s-1');
+
+      expect(mockFetch.mock.calls[0][0]).toBe('/api/stations/s-1/timeline/history');
+    });
+  });
+
+  describe('getTimelineById', () => {
+    it('fetches timeline by ID', async () => {
+      const timeline = { id: 'tl-1', station_id: 's-1', entries: [] };
+      mockFetch.mockResolvedValueOnce(jsonResponse(timeline));
+
+      const result = await getTimelineById('tl-1');
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/timelines/tl-1', undefined);
+      expect(result).toEqual(timeline);
+    });
+  });
+
+  describe('triggerAssembly', () => {
+    it('sends POST to assemble endpoint', async () => {
+      const result = { id: 'tl-1', station_id: 's-1', entries: [], stats: {} };
+      mockFetch.mockResolvedValueOnce(jsonResponse(result, 201));
+
+      const response = await triggerAssembly('s-1');
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/stations/s-1/assemble', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(response).toEqual(result);
     });
   });
 

--- a/apps/tools/src/api.ts
+++ b/apps/tools/src/api.ts
@@ -236,3 +236,71 @@ export async function removeTrack(stationId: string, trackId: string): Promise<v
     { method: 'DELETE' },
   );
 }
+
+// --- Timeline types ---
+
+export interface TimelineEntry {
+  type: 'song' | 'segment';
+  // Song fields
+  canonical_id?: string;
+  artist?: string;
+  title?: string;
+  isrc?: string;
+  // Segment fields
+  segment_id?: string;
+  audio_url?: string;
+  segment_type?: string;
+  script_text?: string;
+  // Shared
+  duration_ms: number;
+}
+
+export interface Timeline {
+  id: string;
+  station_id: string;
+  created_at: string;
+  entries: TimelineEntry[];
+}
+
+export interface TimelineHistoryItem {
+  id: string;
+  created_at: string;
+  entry_count: number;
+  total_duration_ms: number;
+}
+
+export interface AssembleResult extends Timeline {
+  stats: {
+    total_duration_ms: number;
+    song_count: number;
+    segment_count: number;
+    segment_ratio: number;
+  };
+}
+
+// --- Timeline API ---
+
+export async function getTimeline(stationId: string): Promise<Timeline> {
+  return request<Timeline>(`/api/stations/${encodeURIComponent(stationId)}/timeline`);
+}
+
+export async function getTimelineHistory(stationId: string, limit?: number): Promise<TimelineHistoryItem[]> {
+  const params = new URLSearchParams();
+  if (limit !== undefined) params.set('limit', String(limit));
+  const qs = params.toString();
+  return request<TimelineHistoryItem[]>(
+    `/api/stations/${encodeURIComponent(stationId)}/timeline/history${qs ? `?${qs}` : ''}`,
+  );
+}
+
+export async function getTimelineById(id: string): Promise<Timeline> {
+  return request<Timeline>(`/api/timelines/${encodeURIComponent(id)}`);
+}
+
+export async function triggerAssembly(stationId: string): Promise<AssembleResult> {
+  return request<AssembleResult>(`/api/stations/${encodeURIComponent(stationId)}/assemble`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+}

--- a/apps/tools/src/pages/AssemblyDashboard.tsx
+++ b/apps/tools/src/pages/AssemblyDashboard.tsx
@@ -1,0 +1,402 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { Station, Timeline, TimelineEntry, TimelineHistoryItem } from '../api';
+import {
+  getStations,
+  getTimeline,
+  getTimelineHistory,
+  getTimelineById,
+  triggerAssembly,
+} from '../api';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function formatDurationLong(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  return `${m}m ${s}s`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+// ---------------------------------------------------------------------------
+// SegmentPlayer — inline play/stop for segment blocks
+// ---------------------------------------------------------------------------
+
+function SegmentPlayer({ src }: { src?: string }) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [playing, setPlaying] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      audioRef.current?.pause();
+    };
+  }, []);
+
+  if (!src) return null;
+
+  const toggle = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (playing) {
+      audio.pause();
+      setPlaying(false);
+    } else {
+      audio.play().then(() => setPlaying(true)).catch(() => setPlaying(false));
+    }
+  };
+
+  const handleEnded = () => setPlaying(false);
+
+  return (
+    <>
+      <audio ref={audioRef} src={src} onEnded={handleEnded} preload="none" />
+      <button
+        onClick={(e) => { e.stopPropagation(); toggle(); }}
+        className="w-6 h-6 flex items-center justify-center rounded bg-onay-bg border border-onay-border hover:border-onay-gold text-xs shrink-0"
+        aria-label={playing ? 'Stop segment' : 'Play segment'}
+      >
+        {playing ? '\u25A0' : '\u25B6'}
+      </button>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TimelineBlock — renders a single song or segment entry
+// ---------------------------------------------------------------------------
+
+function TimelineBlock({ entry, index }: { entry: TimelineEntry; index: number }) {
+  if (entry.type === 'song') {
+    return (
+      <div className="flex items-center gap-3 px-4 py-3 bg-onay-card border border-onay-border rounded">
+        <span className="text-xs text-onay-muted w-6 text-right shrink-0">{index + 1}</span>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm text-onay-text truncate">{entry.title}</div>
+          <div className="text-xs text-onay-muted truncate">{entry.artist}</div>
+        </div>
+        <span className="text-xs text-onay-muted shrink-0">{formatDuration(entry.duration_ms)}</span>
+      </div>
+    );
+  }
+
+  // Segment entry
+  const typeLabel = entry.segment_type
+    ? entry.segment_type.replace(/_/g, ' ')
+    : entry.segment_id ?? 'segment';
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-3 bg-onay-card border border-onay-border border-l-2 border-l-onay-gold rounded">
+      <span className="text-xs text-onay-muted w-6 text-right shrink-0">{index + 1}</span>
+      <SegmentPlayer src={entry.audio_url} />
+      <div className="flex-1 min-w-0">
+        <span className="text-xs px-2 py-0.5 rounded border border-onay-gold text-onay-gold">
+          {typeLabel}
+        </span>
+        {entry.script_text && (
+          <p className="text-xs text-onay-muted mt-1 truncate">{entry.script_text}</p>
+        )}
+      </div>
+      <span className="text-xs text-onay-muted shrink-0">{formatDuration(entry.duration_ms)}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TimelineView — displays timeline stats + entry list
+// ---------------------------------------------------------------------------
+
+function TimelineView({ timeline }: { timeline: Timeline }) {
+  const stats = {
+    songCount: timeline.entries.filter((e) => e.type === 'song').length,
+    segmentCount: timeline.entries.filter((e) => e.type === 'segment').length,
+    totalDuration: timeline.entries.reduce((sum, e) => sum + e.duration_ms, 0),
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Stats bar */}
+      <div className="flex flex-wrap gap-4 text-xs text-onay-muted px-1">
+        <span>{stats.songCount} songs</span>
+        <span>{stats.segmentCount} segments</span>
+        <span>{formatDurationLong(stats.totalDuration)} total</span>
+        <span>Created {formatDate(timeline.created_at)}</span>
+      </div>
+
+      {/* Entry list */}
+      <div className="space-y-1.5">
+        {timeline.entries.map((entry, i) => {
+          const key = entry.type === 'segment'
+            ? `seg-${entry.segment_id}-${i}`
+            : `song-${entry.canonical_id}-${i}`;
+          return <TimelineBlock key={key} entry={entry} index={i} />;
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AssemblyDashboard
+// ---------------------------------------------------------------------------
+
+export function AssemblyDashboard() {
+  // Station list
+  const [stations, setStations] = useState<Station[]>([]);
+  const [selectedStationId, setSelectedStationId] = useState<string>('');
+  const [loadingStations, setLoadingStations] = useState(true);
+
+  // Current timeline
+  const [timeline, setTimeline] = useState<Timeline | null>(null);
+  const [loadingTimeline, setLoadingTimeline] = useState(false);
+
+  // Assembly
+  const [assembling, setAssembling] = useState(false);
+
+  // History
+  const [history, setHistory] = useState<TimelineHistoryItem[]>([]);
+  const [showHistory, setShowHistory] = useState(false);
+  const [viewingHistoricId, setViewingHistoricId] = useState<string | null>(null);
+  const [historicTimeline, setHistoricTimeline] = useState<Timeline | null>(null);
+  const [loadingHistoric, setLoadingHistoric] = useState(false);
+
+  // Error / success
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  // Load stations
+  useEffect(() => {
+    getStations()
+      .then((s) => {
+        setStations(s);
+        setLoadingStations(false);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : 'Failed to load stations');
+        setLoadingStations(false);
+      });
+  }, []);
+
+  // Load current timeline when station changes
+  const loadTimeline = useCallback(async (stationId: string) => {
+    if (!stationId) {
+      setTimeline(null);
+      setHistory([]);
+      return;
+    }
+    setLoadingTimeline(true);
+    setError(null);
+    setSuccess(null);
+    setViewingHistoricId(null);
+    setHistoricTimeline(null);
+
+    try {
+      const tl = await getTimeline(stationId);
+      setTimeline(tl);
+    } catch {
+      // 404 means no timeline yet — that's fine
+      setTimeline(null);
+    }
+
+    try {
+      const h = await getTimelineHistory(stationId, 20);
+      setHistory(h);
+    } catch {
+      setHistory([]);
+    }
+
+    setLoadingTimeline(false);
+  }, []);
+
+  useEffect(() => {
+    if (selectedStationId) {
+      loadTimeline(selectedStationId);
+    }
+  }, [selectedStationId, loadTimeline]);
+
+  // Assemble
+  const handleAssemble = async () => {
+    if (!selectedStationId) return;
+    setAssembling(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const result = await triggerAssembly(selectedStationId);
+      setTimeline(result);
+      setSuccess(
+        `Assembly complete — ${result.stats.song_count} songs, ${result.stats.segment_count} segments`,
+      );
+      // Refresh history
+      try {
+        const h = await getTimelineHistory(selectedStationId, 20);
+        setHistory(h);
+      } catch { /* ignore */ }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Assembly failed');
+    } finally {
+      setAssembling(false);
+    }
+  };
+
+  // View historic timeline
+  const handleViewHistoric = async (id: string) => {
+    if (id === viewingHistoricId) {
+      setViewingHistoricId(null);
+      setHistoricTimeline(null);
+      return;
+    }
+    setLoadingHistoric(true);
+    setViewingHistoricId(id);
+    try {
+      const tl = await getTimelineById(id);
+      setHistoricTimeline(tl);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load timeline');
+      setViewingHistoricId(null);
+      setHistoricTimeline(null);
+    } finally {
+      setLoadingHistoric(false);
+    }
+  };
+
+  const handleBackToCurrent = () => {
+    setViewingHistoricId(null);
+    setHistoricTimeline(null);
+  };
+
+  // Which timeline to display
+  const displayedTimeline = viewingHistoricId ? historicTimeline : timeline;
+  const isViewingHistoric = viewingHistoricId !== null;
+
+  return (
+    <div className="max-w-4xl mx-auto p-4 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-onay-text">Assembly Dashboard</h1>
+          <p className="text-sm text-onay-muted">Assemble show timelines from tracks + segment library</p>
+        </div>
+      </div>
+
+      {/* Station selector + Assemble button */}
+      <div className="flex items-center gap-3">
+        <select
+          value={selectedStationId}
+          onChange={(e) => setSelectedStationId(e.target.value)}
+          className="flex-1 bg-onay-card border border-onay-border text-onay-text rounded px-3 py-2 text-sm focus:border-onay-gold outline-none"
+          disabled={loadingStations}
+          aria-label="Select station"
+        >
+          <option value="">
+            {loadingStations ? 'Loading stations...' : 'Select a station'}
+          </option>
+          {stations.map((s) => (
+            <option key={s.station_id} value={s.station_id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+
+        <button
+          onClick={handleAssemble}
+          disabled={!selectedStationId || assembling}
+          className="px-4 py-2 text-sm rounded bg-onay-gold/20 text-onay-gold border border-onay-gold/40 hover:bg-onay-gold/30 disabled:opacity-50"
+        >
+          {assembling ? 'Assembling...' : 'Assemble'}
+        </button>
+      </div>
+
+      {/* Messages */}
+      {error && (
+        <div className="p-3 text-sm text-red-400 bg-red-900/20 border border-red-900/40 rounded">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="p-3 text-sm text-green-400 bg-green-900/20 border border-green-900/40 rounded">
+          {success}
+        </div>
+      )}
+
+      {/* Loading */}
+      {loadingTimeline && (
+        <div className="p-4 text-sm text-onay-muted">Loading timeline...</div>
+      )}
+
+      {/* Timeline visualization */}
+      {!loadingTimeline && selectedStationId && (
+        <div className="space-y-4">
+          {isViewingHistoric && (
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleBackToCurrent}
+                className="px-3 py-1.5 text-sm rounded border border-onay-border text-onay-muted hover:text-onay-text"
+              >
+                &larr; Back to current
+              </button>
+              <span className="text-xs text-onay-muted">
+                Viewing historic timeline
+              </span>
+            </div>
+          )}
+
+          {loadingHistoric ? (
+            <div className="p-4 text-sm text-onay-muted">Loading timeline...</div>
+          ) : displayedTimeline ? (
+            <TimelineView timeline={displayedTimeline} />
+          ) : (
+            <div className="p-8 text-center text-sm text-onay-muted">
+              No timeline yet — click Assemble to create one
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* History section */}
+      {!loadingTimeline && selectedStationId && history.length > 0 && (
+        <div className="space-y-3 border-t border-onay-border pt-4">
+          <button
+            onClick={() => setShowHistory(!showHistory)}
+            className="text-sm text-onay-muted hover:text-onay-text"
+          >
+            {showHistory ? '\u25BC' : '\u25B6'} History ({history.length})
+          </button>
+
+          {showHistory && (
+            <div className="space-y-1.5">
+              {history.map((item) => (
+                <button
+                  key={item.id}
+                  onClick={() => handleViewHistoric(item.id)}
+                  className={`w-full text-left flex items-center gap-4 px-4 py-2 rounded border text-sm ${
+                    viewingHistoricId === item.id
+                      ? 'border-onay-gold bg-onay-gold/10 text-onay-gold'
+                      : 'border-onay-border bg-onay-card text-onay-text hover:border-onay-gold/40'
+                  }`}
+                >
+                  <span className="flex-1 truncate">{formatDate(item.created_at)}</span>
+                  <span className="text-xs text-onay-muted">{item.entry_count} entries</span>
+                  <span className="text-xs text-onay-muted">{formatDurationLong(item.total_duration_ms)}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/tools/src/pages/AssemblyDashboard.tsx
+++ b/apps/tools/src/pages/AssemblyDashboard.tsx
@@ -55,7 +55,10 @@ function SegmentPlayer({ src }: { src?: string }) {
       audio.pause();
       setPlaying(false);
     } else {
-      audio.play().then(() => setPlaying(true)).catch(() => setPlaying(false));
+      audio.play().then(() => setPlaying(true)).catch((err) => {
+        console.error('Playback failed:', err);
+        setPlaying(false);
+      });
     }
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16103,6 +16103,7 @@
       "name": "@onay/api",
       "version": "0.1.0",
       "dependencies": {
+        "@onay/assembly": "*",
         "@onay/core": "*",
         "better-sqlite3": "^11.0.0",
         "cors": "^2.8.5",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@onay/assembly": "*",
     "@onay/core": "*",
     "better-sqlite3": "^11.0.0",
     "cors": "^2.8.5",

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -4,6 +4,7 @@ import { healthRouter } from './routes/health.js';
 import { stationsRouter } from './routes/stations.js';
 import { segmentsRouter } from './routes/segments.js';
 import { timelinesRouter } from './routes/timelines.js';
+import { assembleRouter } from './routes/assemble.js';
 
 interface HttpError extends Error {
   status?: number;
@@ -18,6 +19,7 @@ app.use(healthRouter);
 app.use(stationsRouter);
 app.use(segmentsRouter);
 app.use(timelinesRouter);
+app.use(assembleRouter);
 
 app.use((err: HttpError, _req: Request, res: Response, _next: NextFunction) => {
   const status = err.status ?? 500;

--- a/services/api/src/routes/assemble.ts
+++ b/services/api/src/routes/assemble.ts
@@ -1,0 +1,179 @@
+import { Router, type Request, type Response } from 'express';
+import crypto from 'node:crypto';
+import db from '../db.js';
+import {
+  selectSegments,
+  buildManifest,
+  validateManifest,
+  getManifestStats,
+  StubLLMProvider,
+  StubTTSProvider,
+} from '@onay/assembly';
+import type { Station, Segment, TracklistEntry } from '@onay/core';
+
+export const assembleRouter = Router();
+
+interface StationRow {
+  id: string;
+  name: string;
+  description: string | null;
+  genre_tags: string | null;
+  mood_tags: string | null;
+  cover_art_url: string | null;
+  rotation_schedule: string | null;
+}
+
+interface TrackRow {
+  canonical_id: string;
+  artist: string;
+  title: string;
+  isrc: string | null;
+  duration_ms: number;
+}
+
+interface SegmentRow {
+  segment_id: string;
+  type: string;
+  genre_tags: string | null;
+  mood_tags: string | null;
+  artist_refs: string | null;
+  energy_level: number;
+  duration_ms: number;
+  quality_score: number;
+  exaggeration_level: number;
+  usage_count: number;
+  audio_url: string | null;
+  script_text: string;
+  created_at: string;
+}
+
+// POST /api/stations/:id/assemble
+assembleRouter.post('/api/stations/:id/assemble', async (req: Request, res: Response) => {
+  try {
+    // 1. Fetch station
+    const stationRow = db.prepare('SELECT * FROM stations WHERE id = ?').get(req.params.id) as StationRow | undefined;
+    if (!stationRow) {
+      res.status(404).json({ error: 'Station not found' });
+      return;
+    }
+
+    // 2. Fetch tracklist
+    const trackRows = db.prepare(
+      'SELECT canonical_id, artist, title, isrc, duration_ms FROM station_tracks WHERE station_id = ? ORDER BY position'
+    ).all(req.params.id) as TrackRow[];
+
+    if (trackRows.length === 0) {
+      res.status(400).json({ error: 'Station has no tracks' });
+      return;
+    }
+
+    const tracklist: TracklistEntry[] = trackRows.map((r) => ({
+      canonical_id: r.canonical_id,
+      artist: r.artist,
+      title: r.title,
+      ...(r.isrc ? { isrc: r.isrc } : {}),
+      duration_ms: r.duration_ms,
+    }));
+
+    // Build Station object for assembly
+    const station: Station = {
+      station_id: stationRow.id,
+      name: stationRow.name,
+      description: stationRow.description ?? '',
+      genre_tags: JSON.parse(stationRow.genre_tags || '[]'),
+      mood_tags: JSON.parse(stationRow.mood_tags || '[]'),
+      cover_art_url: stationRow.cover_art_url ?? '',
+      rotation_schedule: stationRow.rotation_schedule
+        ? JSON.parse(stationRow.rotation_schedule)
+        : { frequency: 'daily', time_of_day_target: 'evening', days: [] },
+      tracklist,
+      provider_availability: { apple_music: {}, spotify: {} },
+    };
+
+    // 3. Fetch approved segments
+    const segmentRows = db.prepare(
+      "SELECT * FROM segments WHERE status = 'approved'"
+    ).all() as SegmentRow[];
+
+    const library: Segment[] = segmentRows.map((r) => ({
+      segment_id: r.segment_id,
+      type: r.type as Segment['type'],
+      genre_tags: JSON.parse(r.genre_tags || '[]'),
+      mood_tags: JSON.parse(r.mood_tags || '[]'),
+      artist_refs: JSON.parse(r.artist_refs || '[]'),
+      energy_level: r.energy_level,
+      duration_ms: r.duration_ms,
+      quality_score: r.quality_score,
+      exaggeration_level: r.exaggeration_level,
+      usage_count: r.usage_count,
+      audio_url: r.audio_url ?? '',
+      script_text: r.script_text,
+      created_at: r.created_at,
+    }));
+
+    // 4. Run assembly
+    const timeOfDay = typeof req.body?.timeOfDay === 'string' && req.body.timeOfDay.trim()
+      ? req.body.timeOfDay.trim()
+      : 'evening';
+    const rawSeed = req.body?.seed;
+    const seed = typeof rawSeed === 'number' && Number.isFinite(rawSeed) ? rawSeed : Date.now();
+
+    const entries = await selectSegments(station, library, {
+      timeOfDay,
+      variationSeed: seed,
+      llmProvider: new StubLLMProvider(),
+      ttsProvider: new StubTTSProvider(),
+      allowStubs: true,
+    });
+
+    const manifest = buildManifest(station.station_id, entries);
+    const validation = validateManifest(manifest);
+
+    if (!validation.valid) {
+      res.status(500).json({ error: 'Assembly produced invalid manifest', details: validation.errors });
+      return;
+    }
+
+    // 5. Save timeline
+    const timelineId = crypto.randomUUID();
+    const historyId = crypto.randomUUID();
+
+    db.transaction(() => {
+      db.prepare(
+        'INSERT INTO timelines (id, station_id, entries) VALUES (?, ?, ?)'
+      ).run(timelineId, station.station_id, JSON.stringify(manifest.entries));
+
+      db.prepare(
+        'INSERT INTO timeline_history (id, timeline_id, station_id) VALUES (?, ?, ?)'
+      ).run(historyId, timelineId, station.station_id);
+    })();
+
+    // 6. Return the saved timeline with enriched segment data
+    const stats = getManifestStats(manifest);
+
+    // Build segment lookup for enriching response
+    const segmentMap = new Map(library.map((s) => [s.segment_id, s]));
+    const enrichedEntries = manifest.entries.map((entry) => {
+      if (entry.type === 'segment') {
+        const seg = segmentMap.get(entry.segment_id);
+        return {
+          ...entry,
+          segment_type: seg?.type ?? 'unknown',
+          script_text: seg?.script_text ?? '',
+        };
+      }
+      return entry;
+    });
+
+    res.status(201).json({
+      id: timelineId,
+      station_id: station.station_id,
+      created_at: manifest.created_at,
+      entries: enrichedEntries,
+      stats,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Assembly failed';
+    res.status(500).json({ error: message });
+  }
+});


### PR DESCRIPTION
## Summary
- **Assembly Dashboard page** (`apps/tools/src/pages/AssemblyDashboard.tsx`): station selector, "Assemble" button with loading state, vertical timeline visualization (song blocks + gold-bordered segment blocks with type badge, script preview, inline play/stop), stats bar, success/error messages, collapsible history section with click-to-view past timelines
- **`POST /api/stations/:id/assemble` endpoint** (`services/api/src/routes/assemble.ts`): fetches station + tracklist + approved segments, runs `@onay/assembly` selector + manifest builder (stub providers for dev), validates and persists timeline, returns enriched entries with segment type/script
- **Timeline API client functions** in `apps/tools/src/api.ts`: `getTimeline`, `getTimelineHistory`, `getTimelineById`, `triggerAssembly`
- Replaced `/assembly` placeholder route with real `AssemblyDashboard` component
- 16 new tests (11 component + 5 API client), 53 total passing

## Test plan
- [x] `npm run test` in `apps/tools` — 53 tests passing
- [x] `tsc --noEmit` in both `apps/tools` and `services/api` — clean
- [ ] Manual: select station → click Assemble → verify timeline renders with song/segment blocks
- [ ] Manual: click segment play button → verify audio plays/stops
- [ ] Manual: expand History → click past timeline → verify "Back to current" flow
- [ ] Manual: verify `/assembly` nav link active state

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assembly Dashboard: select stations, view current timelines, trigger assemblies, browse history, and play audio segments; includes timeline stats and duration formatting.
  * Server API: new assemble endpoint to create and return assembled timelines and history.

* **Tests**
  * Added comprehensive tests covering dashboard UI flows, timeline API calls, assembly triggering, error states, and history navigation.

* **Chores**
  * Added runtime dependency for assembly support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->